### PR TITLE
fix: use npm install in Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           node-version: 18
           cache: 'npm'
-      - run: npm ci
+      - run: npm install
       - run: npm run build
       - uses: actions/upload-pages-artifact@v3      
         with:


### PR DESCRIPTION
## Summary
- replace `npm ci` with `npm install` in GitHub Pages workflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9a7704270832984fce8656c423f63