### PR TITLE
fix: upload dist folder for pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,6 @@ jobs:
       - run: npm ci
       - run: npm run build
       - uses: actions/upload-pages-artifact@v3
-      - uses: actions/upload-pages-artifact@v3      
         with:
           path: dist
 


### PR DESCRIPTION
## Summary
- fix GitHub Pages workflow to upload the Vite `dist` directory

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb8215669c8329817f1d04a4e9210e