### PR TITLE
Fix audio initialization on mobile devices

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -285,7 +285,10 @@ const App:React.FC = () => {
     timeoutsRef.current = [];
   }
   function startPlayback(startTick:number){
-    if(!audioCtxRef.current) audioCtxRef.current = new AudioContext();
+    if(!audioCtxRef.current){
+      const AC = (window.AudioContext || (window as any).webkitAudioContext) as typeof AudioContext;
+      audioCtxRef.current = new AC();
+    }
     if(audioCtxRef.current.state === 'suspended') audioCtxRef.current.resume();
     clearTimers();
     setPlaying(true);


### PR DESCRIPTION
## Summary
- Ensure mobile Safari support by using `webkitAudioContext` when standard `AudioContext` isn't available

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc1eda9ab083299a0a9d9a63971a28