### PR TITLE
Use icon-based transport controls and sync RTTTL

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,13 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { Den, NoteEvent, KeyDef, KEYS, TICKS_PER_QUARTER, pxPerTick, DUR_STATES, ticksFromDen } from "./music";
+
+import { Den, NoteEvent, KeyDef, KEYS, TICKS_PER_QUARTER, DUR_STATES, ticksFromDen } from "./music";
 import { playTone, getAudioContext } from "./sound";
 import TopControls from "./components/TopControls";
-import Keyboard from "./components/Keyboard";
+import PianoRoll from "./components/PianoRoll";
 import InsertControls from "./components/InsertControls";
 import RTTTLControls from "./components/RTTTLControls";
 import MorseControls from "./components/MorseControls";
+import { parseRTTTL, generateRTTTL } from "./rtttl";
 
 
 const App:React.FC = () => {
@@ -25,25 +27,15 @@ const App:React.FC = () => {
   const [cursorTick,setCursorTick] = useState(0);
   const cursorRef = useRef(0);
   useEffect(()=>{ cursorRef.current = cursorTick; },[cursorTick]);
+  const updateCursor = (tick:number) => { cursorRef.current = tick; setCursorTick(tick); };
   const [nextLen,setNextLen] = useState<Den>(4);
   const [nextDot,setNextDot] = useState(false);
   const [keyboardMode,setKeyboardMode] = useState(false);
   const [playing,setPlaying] = useState(false);
   const [playTick,setPlayTick] = useState(0);
   const [loop,setLoop] = useState(false);
-
-  const gridRef = useRef<HTMLDivElement>(null);
-  const gridContentRef = useRef<HTMLDivElement>(null);
-  const [colWidth,setColWidth] = useState(20);
-
-  useEffect(()=>{
-    const ro = new ResizeObserver((entries: ResizeObserverEntry[])=>{
-      const w = entries[0].contentRect.width;
-      setColWidth(Math.floor(w/48));
-    });
-    if(gridRef.current) ro.observe(gridRef.current);
-    return ()=>ro.disconnect();
-  },[]);
+  const [rtttl,setRtttl] = useState('');
+  const skipParseRef = useRef(false);
 
   // Derived
   const noteWithTiming = notes.reduce<{ev:NoteEvent;startTick:number;durTicks:number}[]>((arr: {ev:NoteEvent;startTick:number;durTicks:number}[], ev: NoteEvent)=>{
@@ -54,18 +46,24 @@ const App:React.FC = () => {
   },[]);
   const totalTicks = noteWithTiming.reduce((s: number, n: {ev:NoteEvent;startTick:number;durTicks:number})=>s+n.durTicks,0);
   const tickSec = 60 / bpm / TICKS_PER_QUARTER;
-  const gridWidth = KEYS.length*colWidth;
-  const gridHeight = Math.max(240,totalTicks*pxPerTick+40);
 
-  // Scroll
   useEffect(()=>{
-    const t = playing? playTick : cursorTick;
-    const cont = gridRef.current; const contentH = gridHeight;
-    if(cont){
-      const target = contentH - t*pxPerTick - cont.clientHeight/2;
-      cont.scrollTop = Math.max(0,Math.min(target,contentH));
+    skipParseRef.current = true;
+    setRtttl(generateRTTTL(name,defDen,bpm,notes));
+  },[name,defDen,bpm,notes]);
+
+  useEffect(()=>{
+    if(skipParseRef.current){ skipParseRef.current=false; return; }
+    try{
+      const song = parseRTTTL(rtttl, defDen, bpm);
+      clearTimers();
+      setPlaying(false);
+      setName(song.name); setDefDen(song.defDen); setBpm(song.bpm); setNotes(song.notes);
+      cursorRef.current = 0; setCursorTick(0); setPlayTick(0);
+    }catch(err){
+      // ignore parse errors
     }
-  },[playTick,cursorTick,playing,gridHeight]);
+  },[rtttl]);
 
 
   // Insert helper
@@ -235,16 +233,21 @@ const App:React.FC = () => {
     }
     startPlayback(cursorTick);
   }
-
-  // Grid click
-  function onGridClick(e:React.MouseEvent){
-    const rect = gridContentRef.current!.getBoundingClientRect();
-    const y = rect.bottom - e.clientY;
-    const tick = Math.max(0,Math.round(y/pxPerTick));
-    cursorRef.current = tick;
-    setCursorTick(tick);
+  function goToStart(){
+    clearTimers();
+    setPlaying(false);
+    cursorRef.current = 0;
+    setCursorTick(0);
+    setPlayTick(0);
   }
 
+  function goToEnd(){
+    clearTimers();
+    setPlaying(false);
+    cursorRef.current = totalTicks;
+    setCursorTick(totalTicks);
+    setPlayTick(totalTicks);
+  }
   // Dev self-test
   useEffect(()=>{
     console.assert(DUR_STATES.length===12,'duration states length');
@@ -277,32 +280,24 @@ const App:React.FC = () => {
           setLoop={setLoop}
           playing={playing}
           togglePlay={togglePlay}
+          goToStart={goToStart}
+          goToEnd={goToEnd}
         />
 
-      {/* Grid */}
-      <div className="flex-1 overflow-hidden">
-        <div ref={gridRef} className="overflow-y-scroll h-72 md:h-[520px] relative" onClick={onGridClick}>
-          <div ref={gridContentRef} className="relative mx-auto" style={{width:gridWidth,height:gridHeight}}>
-            {Array.from({length:KEYS.length}).map((_: unknown, i: number)=>(
-              <div key={i} className="absolute top-0 bottom-0 border-l border-gray-400/20" style={{left:i*colWidth}} />
-            ))}
-            {Array.from({length:Math.floor(totalTicks/TICKS_PER_QUARTER)+1}).map((_: unknown, i: number)=>(
-              <div key={i} className="absolute left-0 right-0 border-b border-gray-400/20" style={{bottom:i*TICKS_PER_QUARTER*pxPerTick}} />
-            ))}
-            {noteWithTiming.map((n: {ev:NoteEvent;startTick:number;durTicks:number})=> n.ev.isRest ? (
-              <div key={n.ev.id} onClick={(e: React.MouseEvent<HTMLDivElement>)=>{e.stopPropagation();toggleSelect(n.ev.id);}} className={`absolute left-0 w-full ${selected.has(n.ev.id)?'bg-gray-500/50':'bg-gray-400/30'} text-center italic`} style={{height:n.durTicks*pxPerTick,bottom:n.startTick*pxPerTick}}>
-                pause
-              </div>
-            ):(
-              <div key={n.ev.id} onClick={(e: React.MouseEvent<HTMLDivElement>)=>{e.stopPropagation();toggleSelect(n.ev.id);}} className={`absolute rounded ${selected.has(n.ev.id)?'bg-blue-400':'bg-blue-600'}`} style={{height:n.durTicks*pxPerTick,width:colWidth-2,left:n.ev.keyIndex!*colWidth+1,bottom:n.startTick*pxPerTick}} />
-            ))}
-            <div className="absolute left-0 right-0 h-0.5 bg-red-500" style={{bottom:(playing?playTick:cursorTick)*pxPerTick}} />
-          </div>
-        </div>
-      </div>
+      {/* Piano roll */}
+      <PianoRoll
+        keys={KEYS}
+        noteWithTiming={noteWithTiming}
+        totalTicks={totalTicks}
+        selected={selected}
+        toggleSelect={toggleSelect}
+        cursorTick={cursorTick}
+        setCursorTick={updateCursor}
+        playing={playing}
+        playTick={playTick}
+        onKeyPress={onKeyPress}
+      />
 
-      {/* Keyboard */}
-        <Keyboard keys={KEYS} colWidth={colWidth} onKeyPress={onKeyPress} />
       {/* Under keyboard toolbar */}
       <InsertControls
         nextLen={nextLen}
@@ -318,11 +313,8 @@ const App:React.FC = () => {
       {/* Bottom panels */}
       <div className="flex flex-1 overflow-hidden flex-col md:flex-row">
         <RTTTLControls
-          name={name}
-          defDen={defDen}
-          bpm={bpm}
-          notes={notes}
-          onImport={(song)=>{ setName(song.name); setDefDen(song.defDen); setBpm(song.bpm); setNotes(song.notes); cursorRef.current = 0; setCursorTick(0); setPlayTick(0); }}
+          rtttl={rtttl}
+          setRtttl={setRtttl}
         />
         <MorseControls
           onAdd={(events)=>events.forEach(insertEvent)}

--- a/src/components/PianoRoll.tsx
+++ b/src/components/PianoRoll.tsx
@@ -1,0 +1,152 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { KeyDef, NoteEvent, TICKS_PER_QUARTER, pxPerTick } from '../music';
+import Keyboard from './Keyboard';
+
+interface NoteWithTiming {
+  ev: NoteEvent;
+  startTick: number;
+  durTicks: number;
+}
+
+interface Props {
+  keys: KeyDef[];
+  noteWithTiming: NoteWithTiming[];
+  totalTicks: number;
+  selected: Set<string>;
+  toggleSelect: (id: string) => void;
+  cursorTick: number;
+  setCursorTick: (tick: number) => void;
+  playing: boolean;
+  playTick: number;
+  onKeyPress: (k: KeyDef) => void;
+}
+
+const PianoRoll: React.FC<Props> = ({
+  keys,
+  noteWithTiming,
+  totalTicks,
+  selected,
+  toggleSelect,
+  cursorTick,
+  setCursorTick,
+  playing,
+  playTick,
+  onKeyPress,
+}) => {
+  const gridRef = useRef<HTMLDivElement>(null);
+  const gridContentRef = useRef<HTMLDivElement>(null);
+  const [colWidth, setColWidth] = useState(20);
+
+  useEffect(() => {
+    const ro = new ResizeObserver((entries) => {
+      const w = entries[0].contentRect.width;
+      setColWidth(Math.floor(w / 48));
+    });
+    if (gridRef.current) ro.observe(gridRef.current);
+    return () => ro.disconnect();
+  }, []);
+
+  const gridWidth = keys.length * colWidth;
+  const gridHeight = Math.max(240, totalTicks * pxPerTick + 40);
+
+  useEffect(() => {
+    const t = playing ? playTick : cursorTick;
+    const cont = gridRef.current;
+    const contentH = gridHeight;
+    if (cont) {
+      const target = contentH - t * pxPerTick - cont.clientHeight / 2;
+      cont.scrollTop = Math.max(0, Math.min(target, contentH));
+    }
+  }, [playTick, cursorTick, playing, gridHeight]);
+
+  function onGridClick(e: React.MouseEvent) {
+    const rect = gridContentRef.current!.getBoundingClientRect();
+    const y = rect.bottom - e.clientY;
+    const tick = Math.max(0, Math.round(y / pxPerTick));
+    setCursorTick(tick);
+  }
+
+  return (
+    <>
+      <div className="flex-1 overflow-hidden">
+        <div
+          ref={gridRef}
+          className="overflow-y-scroll h-72 md:h-[520px] relative"
+          onClick={onGridClick}
+        >
+          <div
+            ref={gridContentRef}
+            className="relative mx-auto"
+            style={{ width: gridWidth, height: gridHeight }}
+          >
+            {Array.from({ length: keys.length }).map((_, i) => (
+              <div
+                key={i}
+                className="absolute top-0 bottom-0 border-l border-gray-400/20"
+                style={{ left: i * colWidth }}
+              />
+            ))}
+            {Array.from({
+              length: Math.floor(totalTicks / TICKS_PER_QUARTER) + 1,
+            }).map((_, i) => (
+              <div
+                key={i}
+                className="absolute left-0 right-0 border-b border-gray-400/20"
+                style={{ bottom: i * TICKS_PER_QUARTER * pxPerTick }}
+              />
+            ))}
+            {noteWithTiming.map((n) =>
+              n.ev.isRest ? (
+                <div
+                  key={n.ev.id}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    toggleSelect(n.ev.id);
+                  }}
+                  className={`absolute left-0 w-full ${
+                    selected.has(n.ev.id)
+                      ? 'bg-gray-500/50'
+                      : 'bg-gray-400/30'
+                  } text-center italic`}
+                  style={{
+                    height: n.durTicks * pxPerTick,
+                    bottom: n.startTick * pxPerTick,
+                  }}
+                >
+                  pause
+                </div>
+              ) : (
+                <div
+                  key={n.ev.id}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    toggleSelect(n.ev.id);
+                  }}
+                  className={`absolute rounded ${
+                    selected.has(n.ev.id)
+                      ? 'bg-blue-400'
+                      : 'bg-blue-600'
+                  }`}
+                  style={{
+                    height: n.durTicks * pxPerTick,
+                    width: colWidth - 2,
+                    left: n.ev.keyIndex! * colWidth + 1,
+                    bottom: n.startTick * pxPerTick,
+                  }}
+                />
+              )
+            )}
+            <div
+              className="absolute left-0 right-0 h-0.5 bg-red-500"
+              style={{ bottom: (playing ? playTick : cursorTick) * pxPerTick }}
+            />
+          </div>
+        </div>
+      </div>
+      <Keyboard keys={keys} colWidth={colWidth} onKeyPress={onKeyPress} />
+    </>
+  );
+};
+
+export default PianoRoll;
+

--- a/src/components/RTTTLControls.tsx
+++ b/src/components/RTTTLControls.tsx
@@ -1,43 +1,25 @@
-import React, { useState } from 'react';
-import { Den, NoteEvent } from '../music';
-import { parseRTTTL as parseRTTTLString, generateRTTTL as generateRTTTLString } from '../rtttl';
+import React from 'react';
 
 interface Props {
-  name: string;
-  defDen: Den;
-  bpm: number;
-  notes: NoteEvent[];
-  onImport: (song: { name: string; defDen: Den; bpm: number; notes: NoteEvent[] }) => void;
+  rtttl: string;
+  setRtttl: (v: string) => void;
 }
 
-const RTTTLControls: React.FC<Props> = ({ name, defDen, bpm, notes, onImport }) => {
-  const [rtttlText, setRtttlText] = useState('');
-
-  function parseRTTTL() {
-    try {
-      const song = parseRTTTLString(rtttlText.trim(), defDen, bpm);
-      onImport(song);
-    } catch (err) {
-      console.error(err);
-    }
-  }
-
-  function generateRTTTL() {
-    const txt = generateRTTTLString(name, defDen, bpm, notes);
-    setRtttlText(txt);
-    navigator.clipboard.writeText(txt);
-  }
-
-  return (
-    <div className="flex-1 p-2 flex flex-col">
-      <div className="font-bold">RTTTL Text</div>
-      <textarea className="flex-1 border p-1 mt-1" value={rtttlText} onChange={e=>setRtttlText(e.target.value)} />
-      <div className="mt-1 flex gap-2">
-        <button className="border px-2" onClick={parseRTTTL}>Parse → Grid</button>
-        <button className="border px-2" onClick={generateRTTTL}>Generate & Copy</button>
-      </div>
+const RTTTLControls: React.FC<Props> = ({ rtttl, setRtttl }) => (
+  <div className="flex-1 p-2 flex flex-col">
+    <div className="font-bold">RTTTL Text</div>
+    <textarea className="flex-1 border p-1 mt-1" value={rtttl} onChange={e=>setRtttl(e.target.value)} />
+    <div className="mt-1 flex gap-2">
+      <button
+        className="border px-2"
+        onClick={()=>navigator.clipboard.writeText(rtttl)}
+        aria-label="Copy RTTTL to clipboard"
+        title="Copy RTTTL to clipboard"
+      >
+        Copy
+      </button>
     </div>
-  );
-};
+  </div>
+);
 
 export default RTTTLControls;

--- a/src/components/TopControls.tsx
+++ b/src/components/TopControls.tsx
@@ -23,13 +23,16 @@ interface Props {
   setLoop: (v: boolean) => void;
   playing: boolean;
   togglePlay: () => void;
+  goToStart: () => void;
+  goToEnd: () => void;
 }
 
 const TopControls: React.FC<Props> = ({
   name, setName, bpm, setBpm, defDen, setDefDen,
   notesLength, totalTicks, lengthSec, selectedSize,
   copySel, cutSel, pasteClip, delSel, clipboardLength,
-  dark, setDark, loop, setLoop, playing, togglePlay
+  dark, setDark, loop, setLoop, playing, togglePlay,
+  goToStart, goToEnd
 }) => (
   <div className="flex gap-4 p-2 items-center flex-wrap text-xs">
     <label className="flex items-center gap-1">Name
@@ -59,8 +62,38 @@ const TopControls: React.FC<Props> = ({
     </div>
     <div className="flex gap-2 items-center ml-auto">
       <button className="border px-2" onClick={()=>setDark(!dark)}>{dark?'Light':'Dark'}</button>
-      <button className={`border px-2 ${loop?'bg-blue-500 text-white':''}`} onClick={()=>setLoop(!loop)}>{loop?'Looping':'Loop'}</button>
-      <button className="border px-2" onClick={togglePlay}>{playing?'Stop':'Play'}</button>
+      <button
+        className="border px-2"
+        onClick={goToStart}
+        aria-label="Go to start"
+        title="Go to start"
+      >
+        ⏮
+      </button>
+      <button
+        className="border px-2"
+        onClick={goToEnd}
+        aria-label="Go to end"
+        title="Go to end"
+      >
+        ⏭
+      </button>
+      <button
+        className={`border px-2 ${loop?'bg-blue-500 text-white':''}`}
+        onClick={()=>setLoop(!loop)}
+        aria-label="Toggle loop"
+        title="Toggle loop"
+      >
+        🔁
+      </button>
+      <button
+        className="border px-2"
+        onClick={togglePlay}
+        aria-label={playing ? 'Pause' : 'Play'}
+        title={playing ? 'Pause' : 'Play'}
+      >
+        {playing?'⏸':'▶️'}
+      </button>
       <span className="text-[10px]">Shift+Enter to Play/Stop</span>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Replace textual play and loop buttons with icons and add start/end controls to move the playhead
- Keep RTTTL text in sync with the piano roll by auto-generating from notes and parsing edits
- Simplify RTTTL panel to a live-updating textarea with copy support
- Use emoji play button (▶️) for transport controls
- Improve accessibility of transport buttons and RTTTL copy control
- Merge latest changes from `main`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc4629b17483298f6f02e94a475f65