### PR TITLE
Improve controls UI, keyboard mode, alignment, and sound

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -132,7 +132,7 @@ const App:React.FC = () => {
       if(e.key===' ' && keyboardMode){ e.preventDefault(); insertRest(); }
       if(keyboardMode){
         const map = 'qwertyuiop[]';
-        const idx = map.indexOf(e.key);
+        const idx = map.indexOf(e.key.toLowerCase());
         if(idx>=0){
           e.preventDefault();
           const base = KEYS.findIndex(k=>k.name==='C' && k.octave===5);

--- a/src/components/PianoRoll.tsx
+++ b/src/components/PianoRoll.tsx
@@ -67,18 +67,17 @@ const PianoRoll: React.FC<Props> = ({
   }
 
   return (
-    <>
-      <div className="flex-1 overflow-hidden">
+    <div className="flex flex-col">
+      <div
+        ref={gridRef}
+        className="overflow-y-scroll h-72 md:h-[520px] relative"
+        onClick={onGridClick}
+      >
         <div
-          ref={gridRef}
-          className="overflow-y-scroll h-72 md:h-[520px] relative"
-          onClick={onGridClick}
+          ref={gridContentRef}
+          className="relative mx-auto"
+          style={{ width: gridWidth, height: gridHeight }}
         >
-          <div
-            ref={gridContentRef}
-            className="relative mx-auto"
-            style={{ width: gridWidth, height: gridHeight }}
-          >
             {Array.from({ length: keys.length }).map((_, i) => (
               <div
                 key={i}
@@ -142,9 +141,10 @@ const PianoRoll: React.FC<Props> = ({
             />
           </div>
         </div>
+      <div className="mx-auto" style={{ width: gridWidth }}>
+        <Keyboard keys={keys} colWidth={colWidth} onKeyPress={onKeyPress} />
       </div>
-      <Keyboard keys={keys} colWidth={colWidth} onKeyPress={onKeyPress} />
-    </>
+    </div>
   );
 };
 

--- a/src/components/TopControls.tsx
+++ b/src/components/TopControls.tsx
@@ -63,7 +63,7 @@ const TopControls: React.FC<Props> = ({
     <div className="flex gap-2 items-center ml-auto">
       <button className="border px-2" onClick={()=>setDark(!dark)}>{dark?'Light':'Dark'}</button>
       <button
-        className="border px-2"
+        className="text-2xl"
         onClick={goToStart}
         aria-label="Go to start"
         title="Go to start"
@@ -71,7 +71,15 @@ const TopControls: React.FC<Props> = ({
         ⏮
       </button>
       <button
-        className="border px-2"
+        className="text-2xl"
+        onClick={togglePlay}
+        aria-label={playing ? 'Pause' : 'Play'}
+        title={playing ? 'Pause' : 'Play'}
+      >
+        {playing?'⏸':'▶️'}
+      </button>
+      <button
+        className="text-2xl"
         onClick={goToEnd}
         aria-label="Go to end"
         title="Go to end"
@@ -79,20 +87,12 @@ const TopControls: React.FC<Props> = ({
         ⏭
       </button>
       <button
-        className={`border px-2 ${loop?'bg-blue-500 text-white':''}`}
+        className={`text-2xl ${loop ? 'text-blue-500' : ''}`}
         onClick={()=>setLoop(!loop)}
         aria-label="Toggle loop"
         title="Toggle loop"
       >
         🔁
-      </button>
-      <button
-        className="border px-2"
-        onClick={togglePlay}
-        aria-label={playing ? 'Pause' : 'Play'}
-        title={playing ? 'Pause' : 'Play'}
-      >
-        {playing?'⏸':'▶️'}
       </button>
       <span className="text-[10px]">Shift+Enter to Play/Stop</span>
     </div>

--- a/src/sound.ts
+++ b/src/sound.ts
@@ -16,17 +16,17 @@ export function getAudioContext(): AudioContext {
   return audioCtx;
 }
 
-export function playTone(midi: number, dur = 0.3) {
+export function playTone(midi: number, dur = 0.15) {
   const ctx = getAudioContext();
   const osc = ctx.createOscillator();
   const gain = ctx.createGain();
-  osc.type = 'sine';
+  osc.type = 'square';
   osc.frequency.value = 440 * Math.pow(2, (midi - 69) / 12);
   osc.connect(gain).connect(ctx.destination);
   const now = ctx.currentTime;
   osc.start(now);
-  gain.gain.setValueAtTime(0.001, now);
-  gain.gain.linearRampToValueAtTime(0.3, now + 0.01);
-  gain.gain.linearRampToValueAtTime(0.001, now + dur);
-  osc.stop(now + dur + 0.05);
+  gain.gain.setValueAtTime(0.2, now);
+  gain.gain.setValueAtTime(0.2, now + dur);
+  gain.gain.linearRampToValueAtTime(0.0001, now + dur + 0.01);
+  osc.stop(now + dur + 0.02);
 }


### PR DESCRIPTION
## Summary
- Enlarge transport buttons, remove borders, and reorder to back/play/forward/loop.
- Make keyboard mode case-insensitive for reliable QWERTY input.
- Align keyboard with grid and remove gap for accurate note placement.
- Swap sine tone for short square-wave beep to mimic pager-like sound.

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bcc4f928788329bc063fc1aa96ad36