### PR TITLE
Refine piano roll layout and transport controls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -276,12 +276,6 @@ const App:React.FC = () => {
           clipboardLength={clipboard.length}
           dark={dark}
           setDark={setDark}
-          loop={loop}
-          setLoop={setLoop}
-          playing={playing}
-          togglePlay={togglePlay}
-          goToStart={goToStart}
-          goToEnd={goToEnd}
         />
 
       {/* Piano roll */}
@@ -306,6 +300,12 @@ const App:React.FC = () => {
         setNextDot={setNextDot}
         insertRest={insertRest}
         clearAll={clearAll}
+        goToStart={goToStart}
+        togglePlay={togglePlay}
+        goToEnd={goToEnd}
+        loop={loop}
+        setLoop={setLoop}
+        playing={playing}
         keyboardMode={keyboardMode}
         setKeyboardMode={setKeyboardMode}
       />

--- a/src/components/InsertControls.tsx
+++ b/src/components/InsertControls.tsx
@@ -8,13 +8,20 @@ interface Props {
   setNextDot: (v: boolean) => void;
   insertRest: () => void;
   clearAll: () => void;
+  goToStart: () => void;
+  togglePlay: () => void;
+  goToEnd: () => void;
+  loop: boolean;
+  setLoop: (v: boolean) => void;
+  playing: boolean;
   keyboardMode: boolean;
   setKeyboardMode: (v: boolean) => void;
 }
 
 const InsertControls: React.FC<Props> = ({
   nextLen, setNextLen, nextDot, setNextDot,
-  insertRest, clearAll, keyboardMode, setKeyboardMode
+  insertRest, clearAll, goToStart, togglePlay, goToEnd,
+  loop, setLoop, playing, keyboardMode, setKeyboardMode
 }) => (
   <div className="flex flex-wrap gap-2 p-2 items-center text-xs border-b">
     <label>
@@ -28,6 +35,40 @@ const InsertControls: React.FC<Props> = ({
     </label>
     <button className="border px-1" onClick={insertRest}>+ Pause</button>
     <button className="border px-1" onClick={clearAll}>Clear</button>
+    <div className="flex items-center gap-2 ml-2">
+      <button
+        className="text-2xl"
+        onClick={goToStart}
+        aria-label="Go to start"
+        title="Go to start"
+      >
+        ⏮
+      </button>
+      <button
+        className="text-2xl"
+        onClick={togglePlay}
+        aria-label={playing ? 'Pause' : 'Play'}
+        title={playing ? 'Pause' : 'Play'}
+      >
+        {playing ? '⏸' : '▶️'}
+      </button>
+      <button
+        className="text-2xl"
+        onClick={goToEnd}
+        aria-label="Go to end"
+        title="Go to end"
+      >
+        ⏭
+      </button>
+      <button
+        className={`text-2xl ${loop ? 'text-blue-500' : ''}`}
+        onClick={() => setLoop(!loop)}
+        aria-label="Toggle loop"
+        title="Toggle loop"
+      >
+        🔁
+      </button>
+    </div>
     <label className="mt-2 md:ml-auto flex items-center gap-1 w-full md:w-auto justify-end">
       <input type="checkbox" checked={keyboardMode} onChange={e=>setKeyboardMode(!!e.target.checked)} /> Keyboard mode
       <span className="italic">QWERTYUIOP[] = C5..B5, Space=pause</span>

--- a/src/components/PianoRoll.tsx
+++ b/src/components/PianoRoll.tsx
@@ -40,11 +40,11 @@ const PianoRoll: React.FC<Props> = ({
   useEffect(() => {
     const ro = new ResizeObserver((entries) => {
       const w = entries[0].contentRect.width;
-      setColWidth(Math.floor(w / 48));
+      setColWidth(w / keys.length);
     });
     if (gridRef.current) ro.observe(gridRef.current);
     return () => ro.disconnect();
-  }, []);
+  }, [keys.length]);
 
   const gridWidth = keys.length * colWidth;
   const gridHeight = Math.max(240, totalTicks * pxPerTick + 40);
@@ -54,8 +54,9 @@ const PianoRoll: React.FC<Props> = ({
     const cont = gridRef.current;
     const contentH = gridHeight;
     if (cont) {
-      const target = contentH - t * pxPerTick - cont.clientHeight / 2;
-      cont.scrollTop = Math.max(0, Math.min(target, contentH));
+      const maxScroll = Math.max(0, contentH - cont.clientHeight);
+      const target = contentH - t * pxPerTick - cont.clientHeight;
+      cont.scrollTop = Math.max(0, Math.min(target, maxScroll));
     }
   }, [playTick, cursorTick, playing, gridHeight]);
 

--- a/src/components/TopControls.tsx
+++ b/src/components/TopControls.tsx
@@ -19,20 +19,13 @@ interface Props {
   clipboardLength: number;
   dark: boolean;
   setDark: (v: boolean) => void;
-  loop: boolean;
-  setLoop: (v: boolean) => void;
-  playing: boolean;
-  togglePlay: () => void;
-  goToStart: () => void;
-  goToEnd: () => void;
 }
 
 const TopControls: React.FC<Props> = ({
   name, setName, bpm, setBpm, defDen, setDefDen,
   notesLength, totalTicks, lengthSec, selectedSize,
   copySel, cutSel, pasteClip, delSel, clipboardLength,
-  dark, setDark, loop, setLoop, playing, togglePlay,
-  goToStart, goToEnd
+  dark, setDark
 }) => (
   <div className="flex gap-4 p-2 items-center flex-wrap text-xs">
     <label className="flex items-center gap-1">Name
@@ -60,42 +53,14 @@ const TopControls: React.FC<Props> = ({
         <button className="border px-1" onClick={delSel}>Delete</button>
       </div>
     </div>
-    <div className="flex gap-2 items-center ml-auto">
-      <button className="border px-2" onClick={()=>setDark(!dark)}>{dark?'Light':'Dark'}</button>
-      <button
-        className="text-2xl"
-        onClick={goToStart}
-        aria-label="Go to start"
-        title="Go to start"
-      >
-        ⏮
-      </button>
-      <button
-        className="text-2xl"
-        onClick={togglePlay}
-        aria-label={playing ? 'Pause' : 'Play'}
-        title={playing ? 'Pause' : 'Play'}
-      >
-        {playing?'⏸':'▶️'}
-      </button>
-      <button
-        className="text-2xl"
-        onClick={goToEnd}
-        aria-label="Go to end"
-        title="Go to end"
-      >
-        ⏭
-      </button>
-      <button
-        className={`text-2xl ${loop ? 'text-blue-500' : ''}`}
-        onClick={()=>setLoop(!loop)}
-        aria-label="Toggle loop"
-        title="Toggle loop"
-      >
-        🔁
-      </button>
-      <span className="text-[10px]">Shift+Enter to Play/Stop</span>
-    </div>
+    <button
+      className="border px-2 ml-auto"
+      onClick={()=>setDark(!dark)}
+      aria-label="Toggle theme"
+      title="Toggle theme"
+    >
+      {dark ? '🌞' : '🌙'}
+    </button>
   </div>
 );
 


### PR DESCRIPTION
## Summary
- Align piano roll grid with keyboard and anchor playhead at keyboard level
- Replace text theme toggle with sun/moon icon at top right
- Move playback controls below keyboard alongside Clear button

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bcc9a3d7008329b89592807c0f8b38