### PR TITLE
Align grid, update defaults, highlight pauses, and auto screenshot

### DIFF
--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -1,0 +1,31 @@
+name: Update Screenshot
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: write
+
+jobs:
+  screenshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm run build
+      - run: npm run screenshot
+      - uses: EndBug/add-and-commit@v9
+        with:
+          add: screenshot.png
+          message: "chore: update screenshot [skip ci]"
+      - uses: actions/upload-artifact@v3
+        with:
+          name: screenshot
+          path: screenshot.png
+

--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -11,10 +11,10 @@ jobs:
   screenshot:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
       - run: npm ci
@@ -24,7 +24,7 @@ jobs:
         with:
           add: screenshot.png
           message: "chore: update screenshot [skip ci]"
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: screenshot
           path: screenshot.png

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@types/react-dom": "^18.0.11",
         "@vitejs/plugin-react": "^4.0.0",
         "autoprefixer": "^10.4.14",
+        "playwright": "^1.55.0",
         "postcss": "^8.4.21",
         "tailwindcss": "^3.3.0",
         "typescript": "^5.0.2",
@@ -2263,6 +2264,50 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "echo \"No tests\""
+    "test": "echo \"No tests\"",
+    "screenshot": "node scripts/screenshot.mjs"
   },
   "keywords": [],
   "author": "",
@@ -23,6 +24,7 @@
     "@types/react-dom": "^18.0.11",
     "@vitejs/plugin-react": "^4.0.0",
     "autoprefixer": "^10.4.14",
+    "playwright": "^1.55.0",
     "postcss": "^8.4.21",
     "tailwindcss": "^3.3.0",
     "typescript": "^5.0.2",

--- a/scripts/screenshot.mjs
+++ b/scripts/screenshot.mjs
@@ -1,0 +1,30 @@
+import { chromium } from 'playwright';
+import { spawn } from 'child_process';
+
+async function waitForServer(url, timeout = 10000) {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+    } catch (e) {
+      // ignore errors
+    }
+    await new Promise(r => setTimeout(r, 500));
+  }
+  throw new Error('Server did not start in time');
+}
+
+async function run() {
+  const server = spawn('npm', ['run', 'preview'], { stdio: 'inherit' });
+  await waitForServer('http://localhost:4173');
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  await page.goto('http://localhost:4173');
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.screenshot({ path: 'screenshot.png', fullPage: true });
+  await browser.close();
+  server.kill('SIGINT');
+}
+
+run();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,8 +19,8 @@ const App:React.FC = () => {
 
   // State
   const [name,setName] = useState('Tune');
-  const [bpm,setBpm] = useState(120);
-  const [defDen,setDefDen] = useState<Den>(4);
+  const [bpm,setBpm] = useState(170);
+  const [defDen,setDefDen] = useState<Den>(8);
   const [notes,setNotes] = useState<NoteEvent[]>([]);
   const [selected,setSelected] = useState<Set<string>>(new Set());
   const [clipboard,setClipboard] = useState<Omit<NoteEvent,'id'>[]>([]);
@@ -28,13 +28,13 @@ const App:React.FC = () => {
   const cursorRef = useRef(0);
   useEffect(()=>{ cursorRef.current = cursorTick; },[cursorTick]);
   const updateCursor = (tick:number) => { cursorRef.current = tick; setCursorTick(tick); };
-  const [nextLen,setNextLen] = useState<Den>(4);
+  const [nextLen,setNextLen] = useState<Den>(8);
   const [nextDot,setNextDot] = useState(false);
   const [keyboardMode,setKeyboardMode] = useState(false);
   const [playing,setPlaying] = useState(false);
   const [playTick,setPlayTick] = useState(0);
   const [loop,setLoop] = useState(false);
-  const [rtttl,setRtttl] = useState('');
+  const [rtttl,setRtttl] = useState('Tune:d=8,o=5,b=170:');
   const skipParseRef = useRef(false);
 
   // Derived

--- a/src/components/Keyboard.tsx
+++ b/src/components/Keyboard.tsx
@@ -13,7 +13,7 @@ const Keyboard: React.FC<Props> = ({ keys, colWidth, onKeyPress }) => (
       <div
         key={k.index}
         onClick={() => onKeyPress(k)}
-        className={`absolute flex items-end justify-center cursor-pointer ${k.isBlack ? 'bg-black text-white' : 'bg-white border'}`}
+        className={`absolute flex items-end justify-center cursor-pointer box-border ${k.isBlack ? 'bg-black text-white' : 'bg-white border'}`}
         style={{left: k.index*colWidth, width: colWidth, height: '100%'}}
       >
         {!k.isBlack && <span className="text-xs text-gray-800">{k.label}</span>}

--- a/src/components/PianoRoll.tsx
+++ b/src/components/PianoRoll.tsx
@@ -71,12 +71,12 @@ const PianoRoll: React.FC<Props> = ({
     <div className="flex flex-col">
       <div
         ref={gridRef}
-        className="overflow-y-scroll h-72 md:h-[520px] relative"
+        className="overflow-y-scroll h-72 md:h-[520px] flex flex-col justify-end"
         onClick={onGridClick}
       >
         <div
           ref={gridContentRef}
-          className="relative mx-auto"
+          className="relative mx-auto flex-none"
           style={{ width: gridWidth, height: gridHeight }}
         >
             {Array.from({ length: keys.length }).map((_, i) => (
@@ -105,7 +105,7 @@ const PianoRoll: React.FC<Props> = ({
                   }}
                   className={`absolute left-0 w-full ${
                     selected.has(n.ev.id)
-                      ? 'bg-gray-500/50'
+                      ? 'bg-yellow-400 text-gray-900 font-semibold'
                       : 'bg-gray-400/30'
                   } text-center italic`}
                   style={{

--- a/src/music.ts
+++ b/src/music.ts
@@ -36,7 +36,7 @@ export const DUR_STATES = [
   {den:2,dotted:false},{den:2,dotted:true},
   {den:1,dotted:false},{den:1,dotted:true},
 ];
-export const TEMPOS = [5,28,31,35,40,45,50,56,63,70,80,90,100,112,125,140,160,180,200,225,250,285,320,355,400,450,500,565,635,715,800,900];
+export const TEMPOS = [5,28,31,35,40,45,50,56,63,70,80,90,100,112,125,140,160,170,180,200,225,250,285,320,355,400,450,500,565,635,715,800,900];
 export const DEFAULT_DENS:Den[] = [1,2,4,8,16,32];
 export const NEXT_DENS:Den[] = [1,2,4,8,16,32];
 


### PR DESCRIPTION
## Summary
- Start piano roll grid at bottom and align keyboard columns
- Default to `Tune:d=8,o=5,b=170:` and matching UI values
- Make selected pauses more visible
- Automatically generate a screenshot for each PR via workflow
- Remove committed `screenshot.png` so PRs don't include binary files

## Testing
- `npm test`
- `npm run screenshot` (generated screenshot, removed before commit)


------
https://chatgpt.com/codex/tasks/task_e_68bcd1e0718c8329a177ee4befb37718