### PR TITLE
Ensure piano roll grid fills available height

### DIFF
--- a/src/components/PianoRoll.tsx
+++ b/src/components/PianoRoll.tsx
@@ -36,18 +36,21 @@ const PianoRoll: React.FC<Props> = ({
   const gridRef = useRef<HTMLDivElement>(null);
   const gridContentRef = useRef<HTMLDivElement>(null);
   const [colWidth, setColWidth] = useState(20);
+  const [containerHeight, setContainerHeight] = useState(240);
 
   useEffect(() => {
     const ro = new ResizeObserver((entries) => {
-      const w = entries[0].contentRect.width;
-      setColWidth(w / keys.length);
+      const rect = entries[0].contentRect;
+      const cw = Math.floor(rect.width / keys.length);
+      setColWidth(cw);
+      setContainerHeight(rect.height);
     });
     if (gridRef.current) ro.observe(gridRef.current);
     return () => ro.disconnect();
   }, [keys.length]);
 
   const gridWidth = keys.length * colWidth;
-  const gridHeight = Math.max(240, totalTicks * pxPerTick + 40);
+  const gridHeight = Math.max(containerHeight, totalTicks * pxPerTick + 40);
 
   useEffect(() => {
     const t = playing ? playTick : cursorTick;


### PR DESCRIPTION
## Summary
- track container height with ResizeObserver
- ensure piano roll grid height fills visible area
- round column width so keyboard matches grid width

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bda0e7e4908329bd685160e9ca2648