### PR TITLE
Center piano roll and allow default octave

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ const App:React.FC = () => {
   const [name,setName] = useState('Tune');
   const [bpm,setBpm] = useState(170);
   const [defDen,setDefDen] = useState<Den>(8);
+  const [defOct,setDefOct] = useState(5);
   const [notes,setNotes] = useState<NoteEvent[]>([]);
   const [selected,setSelected] = useState<Set<string>>(new Set());
   const [clipboard,setClipboard] = useState<Omit<NoteEvent,'id'>[]>([]);
@@ -49,16 +50,16 @@ const App:React.FC = () => {
 
   useEffect(()=>{
     skipParseRef.current = true;
-    setRtttl(generateRTTTL(name,defDen,bpm,notes));
-  },[name,defDen,bpm,notes]);
+    setRtttl(generateRTTTL(name,defDen,defOct,bpm,notes));
+  },[name,defDen,defOct,bpm,notes]);
 
   useEffect(()=>{
     if(skipParseRef.current){ skipParseRef.current=false; return; }
     try{
-      const song = parseRTTTL(rtttl, defDen, bpm);
+      const song = parseRTTTL(rtttl, defDen, defOct, bpm);
       clearTimers();
       setPlaying(false);
-      setName(song.name); setDefDen(song.defDen); setBpm(song.bpm); setNotes(song.notes);
+      setName(song.name); setDefDen(song.defDen); setDefOct(song.defOct); setBpm(song.bpm); setNotes(song.notes);
       cursorRef.current = 0; setCursorTick(0); setPlayTick(0);
     }catch(err){
       // ignore parse errors
@@ -251,7 +252,7 @@ const App:React.FC = () => {
   // Dev self-test
   useEffect(()=>{
     console.assert(DUR_STATES.length===12,'duration states length');
-    const rt = `${name}:d=${defDen},o=5,b=${bpm}:`;
+    const rt = `${name}:d=${defDen},o=${defOct},b=${bpm}:`;
     console.assert(rt.startsWith(name),'rtttl header test');
   },[]);
 
@@ -265,6 +266,8 @@ const App:React.FC = () => {
           setBpm={setBpm}
           defDen={defDen}
           setDefDen={setDefDen}
+          defOct={defOct}
+          setDefOct={setDefOct}
           notesLength={notes.length}
           totalTicks={totalTicks}
           lengthSec={totalTicks*tickSec}

--- a/src/components/PianoRoll.tsx
+++ b/src/components/PianoRoll.tsx
@@ -58,7 +58,7 @@ const PianoRoll: React.FC<Props> = ({
     const contentH = gridHeight;
     if (cont) {
       const maxScroll = Math.max(0, contentH - cont.clientHeight);
-      const target = contentH - t * pxPerTick - cont.clientHeight;
+      const target = contentH - t * pxPerTick - cont.clientHeight / 2;
       cont.scrollTop = Math.max(0, Math.min(target, maxScroll));
     }
   }, [playTick, cursorTick, playing, gridHeight]);

--- a/src/components/TopControls.tsx
+++ b/src/components/TopControls.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Den, TEMPOS, DEFAULT_DENS } from '../music';
 
+const OCTAVES = [4,5,6,7];
+
 interface Props {
   name: string;
   setName: (v: string) => void;
@@ -8,6 +10,8 @@ interface Props {
   setBpm: (v: number) => void;
   defDen: Den;
   setDefDen: (d: Den) => void;
+  defOct: number;
+  setDefOct: (v: number) => void;
   notesLength: number;
   totalTicks: number;
   lengthSec: number;
@@ -22,7 +26,7 @@ interface Props {
 }
 
 const TopControls: React.FC<Props> = ({
-  name, setName, bpm, setBpm, defDen, setDefDen,
+  name, setName, bpm, setBpm, defDen, setDefDen, defOct, setDefOct,
   notesLength, totalTicks, lengthSec, selectedSize,
   copySel, cutSel, pasteClip, delSel, clipboardLength,
   dark, setDark
@@ -39,6 +43,11 @@ const TopControls: React.FC<Props> = ({
     <label className="flex items-center gap-1">Default d
       <select className="border p-1" value={defDen} onChange={e=>setDefDen(parseInt(e.target.value) as Den)}>
         {DEFAULT_DENS.map(t => <option key={t} value={t}>{t}</option>)}
+      </select>
+    </label>
+    <label className="flex items-center gap-1">Default o
+      <select className="border p-1" value={defOct} onChange={e=>setDefOct(parseInt(e.target.value))}>
+        {OCTAVES.map(o => <option key={o} value={o}>{o}</option>)}
       </select>
     </label>
     <div className="flex-1 flex gap-1 flex-wrap items-center">

--- a/src/rtttl.ts
+++ b/src/rtttl.ts
@@ -3,15 +3,16 @@ import { Den, NoteEvent, KEYS, KeyDef } from './music';
 export interface RTTTLSong {
   name: string;
   defDen: Den;
+  defOct: number;
   bpm: number;
   notes: NoteEvent[];
 }
 
-export function parseRTTTL(txt: string, currentDef: Den, currentBpm: number): RTTTLSong {
+export function parseRTTTL(txt: string, currentDef: Den, currentOct: number, currentBpm: number): RTTTLSong {
   const [n, settings, seq] = txt.trim().split(':');
   const parts = settings.split(',');
   let d: Den = currentDef;
-  let o = 5;
+  let o = currentOct;
   let b: number = currentBpm;
   parts.forEach(p => {
     const [k, v] = p.split('=');
@@ -50,17 +51,19 @@ export function parseRTTTL(txt: string, currentDef: Den, currentBpm: number): RT
       evs.push({ id: crypto.randomUUID(), isRest: false, keyIndex, note: name, octave: oct, durationDen: den, dotted: dot });
     }
   });
-  return { name: n, defDen: d, bpm: b, notes: evs };
+  return { name: n, defDen: d, defOct: o, bpm: b, notes: evs };
 }
 
-export function generateRTTTL(name: string, defDen: Den, bpm: number, notes: NoteEvent[]): string {
-  const header = `${name}:d=${defDen},o=5,b=${bpm}:`;
+export function generateRTTTL(name: string, defDen: Den, defOct: number, bpm: number, notes: NoteEvent[]): string {
+  const header = `${name}:d=${defDen},o=${defOct},b=${bpm}:`;
   const body = notes
     .map(n => {
       const dur = n.durationDen !== defDen ? n.durationDen.toString() : '';
       const dot = n.dotted ? '.' : '';
       if (n.isRest) return `${dur}p${dot}`;
-      return `${dur}${n.note?.toLowerCase()}${KEYS[n.keyIndex!].octave}${dot}`;
+      const oct = (n.octave ?? KEYS[n.keyIndex!].octave);
+      const octStr = oct !== defOct ? oct.toString() : '';
+      return `${dur}${n.note!.toLowerCase()}${octStr}${dot}`;
     })
     .join(',');
   return header + body;


### PR DESCRIPTION
## Summary
- Keep cursor and playback centered in the piano roll view
- Make default RTTTL octave configurable via top controls and propagation to generated text
- Omit octave from RTTTL notes when it matches the default

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdf0bb92d08329a69bfd6b03bce605