### PR TITLE
Fix piano roll keyboard alignment

### DIFF
--- a/src/components/InsertControls.tsx
+++ b/src/components/InsertControls.tsx
@@ -61,10 +61,11 @@ const InsertControls: React.FC<Props> = ({
         ⏭
       </button>
       <button
-        className={`text-2xl ${loop ? 'text-blue-500' : ''}`}
+        className={`text-2xl px-1 rounded ${loop ? 'bg-blue-500 text-white' : ''}`}
         onClick={() => setLoop(!loop)}
         aria-label="Toggle loop"
         title="Toggle loop"
+        aria-pressed={loop}
       >
         🔁
       </button>

--- a/src/components/MorseControls.tsx
+++ b/src/components/MorseControls.tsx
@@ -11,12 +11,12 @@ const MorseControls: React.FC<Props> = ({ onAdd }) => {
   const [dotLen, setDotLen] = useState<Den>(8);
   const [dotDot, setDotDot] = useState(false);
   const [dashLen, setDashLen] = useState<Den>(4);
-  const [dashDot, setDashDot] = useState(false);
-  const [symGap, setSymGap] = useState<Den | 'None'>('None');
+  const [dashDot, setDashDot] = useState(true);
+  const [symGap, setSymGap] = useState<Den | 'None'>(8);
   const [symDot, setSymDot] = useState(false);
-  const [letGap, setLetGap] = useState<Den | 'None'>('None');
+  const [letGap, setLetGap] = useState<Den | 'None'>(4);
   const [letDot, setLetDot] = useState(false);
-  const [wordGap, setWordGap] = useState<Den | 'None'>('None');
+  const [wordGap, setWordGap] = useState<Den | 'None'>(2);
   const [wordDot, setWordDot] = useState(false);
   const [scale, setScale] = useState('C Major');
   const [customScale, setCustomScale] = useState('');

--- a/src/components/PianoRoll.tsx
+++ b/src/components/PianoRoll.tsx
@@ -40,10 +40,10 @@ const PianoRoll: React.FC<Props> = ({
 
   useEffect(() => {
     const ro = new ResizeObserver((entries) => {
-      const rect = entries[0].contentRect;
-      const cw = Math.floor(rect.width / keys.length);
+      const w = (entries[0].target as HTMLElement).clientWidth;
+      const cw = w / keys.length;
       setColWidth(cw);
-      setContainerHeight(rect.height);
+      setContainerHeight(entries[0].contentRect.height);
     });
     if (gridRef.current) ro.observe(gridRef.current);
     return () => ro.disconnect();
@@ -71,15 +71,15 @@ const PianoRoll: React.FC<Props> = ({
   }
 
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col w-full items-start">
       <div
         ref={gridRef}
-        className="overflow-y-scroll h-72 md:h-[520px] flex flex-col justify-end"
+        className="w-full overflow-y-scroll h-72 md:h-[520px] flex flex-col items-start justify-end"
         onClick={onGridClick}
       >
         <div
           ref={gridContentRef}
-          className="relative mx-auto flex-none"
+          className="relative flex-none"
           style={{ width: gridWidth, height: gridHeight }}
         >
             {Array.from({ length: keys.length }).map((_, i) => (
@@ -145,9 +145,7 @@ const PianoRoll: React.FC<Props> = ({
             />
           </div>
         </div>
-      <div className="mx-auto" style={{ width: gridWidth }}>
-        <Keyboard keys={keys} colWidth={colWidth} onKeyPress={onKeyPress} />
-      </div>
+      <Keyboard keys={keys} colWidth={colWidth} onKeyPress={onKeyPress} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- compute column width using clientWidth and align grid/keyboard to eliminate left offset
- add visual active state for loop button
- provide default Morse mode settings

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be0b1959cc832989009e5fbb1b9c47