### PR TITLE
Improve UI icons and Morse defaults

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@tabler/icons-react": "^3.34.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "unmute-ios-audio": "^3.3.0"
@@ -1184,6 +1185,32 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tabler/icons": {
+      "version": "3.34.1",
+      "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.34.1.tgz",
+      "integrity": "sha512-9gTnUvd7Fd/DmQgr3MKY+oJLa1RfNsQo8c/ir3TJAWghOuZXodbtbVp0QBY2DxWuuvrSZFys0HEbv1CoiI5y6A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/codecalm"
+      }
+    },
+    "node_modules/@tabler/icons-react": {
+      "version": "3.34.1",
+      "resolved": "https://registry.npmjs.org/@tabler/icons-react/-/icons-react-3.34.1.tgz",
+      "integrity": "sha512-Ld6g0NqOO05kyyHsfU8h787PdHBm7cFmOycQSIrGp45XcXYDuOK2Bs0VC4T2FWSKZ6bx5g04imfzazf/nqtk1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tabler/icons": "3.34.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/codecalm"
+      },
+      "peerDependencies": {
+        "react": ">= 16"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "license": "ISC",
   "type": "module",
   "dependencies": {
+    "@tabler/icons-react": "^3.34.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "unmute-ios-audio": "^3.3.0"

--- a/src/components/InsertControls.tsx
+++ b/src/components/InsertControls.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
 import { Den, NEXT_DENS } from '../music';
+import {
+  IconPlayerSkipBack,
+  IconPlayerPlay,
+  IconPlayerPause,
+  IconPlayerSkipForward,
+  IconRepeat,
+} from '@tabler/icons-react';
 
 interface Props {
   nextLen: Den;
@@ -37,37 +44,37 @@ const InsertControls: React.FC<Props> = ({
     <button className="border px-1" onClick={clearAll}>Clear</button>
     <div className="flex items-center gap-2 ml-2">
       <button
-        className="text-2xl"
+        className="p-1"
         onClick={goToStart}
         aria-label="Go to start"
         title="Go to start"
       >
-        ⏮
+        <IconPlayerSkipBack size={24} />
       </button>
       <button
-        className="text-2xl"
+        className="p-1"
         onClick={togglePlay}
         aria-label={playing ? 'Pause' : 'Play'}
         title={playing ? 'Pause' : 'Play'}
       >
-        {playing ? '⏸' : '▶️'}
+        {playing ? <IconPlayerPause size={24} /> : <IconPlayerPlay size={24} />}
       </button>
       <button
-        className="text-2xl"
+        className="p-1"
         onClick={goToEnd}
         aria-label="Go to end"
         title="Go to end"
       >
-        ⏭
+        <IconPlayerSkipForward size={24} />
       </button>
       <button
-        className={`text-2xl px-1 rounded ${loop ? 'bg-blue-500 text-white' : ''}`}
+        className={`p-1 rounded ${loop ? 'bg-blue-500 text-white' : ''}`}
         onClick={() => setLoop(!loop)}
         aria-label="Toggle loop"
         title="Toggle loop"
         aria-pressed={loop}
       >
-        🔁
+        <IconRepeat size={24} />
       </button>
     </div>
     <label className="mt-2 md:ml-auto flex items-center gap-1 w-full md:w-auto justify-end">

--- a/src/components/MorseControls.tsx
+++ b/src/components/MorseControls.tsx
@@ -8,18 +8,18 @@ interface Props {
 
 const MorseControls: React.FC<Props> = ({ onAdd }) => {
   const [morseText, setMorseText] = useState('');
-  const [dotLen, setDotLen] = useState<Den>(8);
+  const [dotLen, setDotLen] = useState<Den>(32);
   const [dotDot, setDotDot] = useState(false);
-  const [dashLen, setDashLen] = useState<Den>(4);
+  const [dashLen, setDashLen] = useState<Den>(16);
   const [dashDot, setDashDot] = useState(true);
-  const [symGap, setSymGap] = useState<Den | 'None'>(8);
+  const [symGap, setSymGap] = useState<Den | 'None'>(32);
   const [symDot, setSymDot] = useState(false);
-  const [letGap, setLetGap] = useState<Den | 'None'>(4);
-  const [letDot, setLetDot] = useState(false);
-  const [wordGap, setWordGap] = useState<Den | 'None'>(2);
-  const [wordDot, setWordDot] = useState(false);
-  const [scale, setScale] = useState('C Major');
-  const [customScale, setCustomScale] = useState('');
+  const [letGap, setLetGap] = useState<Den | 'None'>(16);
+  const [letDot, setLetDot] = useState(true);
+  const [wordGap, setWordGap] = useState<Den | 'None'>(8);
+  const [wordDot, setWordDot] = useState(true);
+  const [scale, setScale] = useState('Custom');
+  const [customScale, setCustomScale] = useState('C');
   const [morseOct, setMorseOct] = useState(4);
   const scaleIndex = useRef(0);
 

--- a/src/components/PianoRoll.tsx
+++ b/src/components/PianoRoll.tsx
@@ -110,14 +110,12 @@ const PianoRoll: React.FC<Props> = ({
                     selected.has(n.ev.id)
                       ? 'bg-yellow-400 text-gray-900 font-semibold'
                       : 'bg-gray-400/30'
-                  } text-center italic`}
+                  }`}
                   style={{
                     height: n.durTicks * pxPerTick,
                     bottom: n.startTick * pxPerTick,
                   }}
-                >
-                  pause
-                </div>
+                />
               ) : (
                 <div
                   key={n.ev.id}

--- a/src/components/TopControls.tsx
+++ b/src/components/TopControls.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Den, TEMPOS, DEFAULT_DENS } from '../music';
+import { Den, TEMPOS, DEFAULT_DENS, NoteEvent } from '../music';
+import { IconSun, IconMoon } from '@tabler/icons-react';
 
 const OCTAVES = [4,5,6,7];
 
@@ -23,13 +24,14 @@ interface Props {
   clipboardLength: number;
   dark: boolean;
   setDark: (v: boolean) => void;
+  lastSelected: NoteEvent | null;
 }
 
 const TopControls: React.FC<Props> = ({
   name, setName, bpm, setBpm, defDen, setDefDen, defOct, setDefOct,
   notesLength, totalTicks, lengthSec, selectedSize,
   copySel, cutSel, pasteClip, delSel, clipboardLength,
-  dark, setDark
+  dark, setDark, lastSelected
 }) => (
   <div className="flex gap-4 p-2 items-center flex-wrap text-xs">
     <label className="flex items-center gap-1">Name
@@ -54,7 +56,19 @@ const TopControls: React.FC<Props> = ({
       <div>Events: {notesLength}</div>
       <div>Total ticks: {totalTicks}</div>
       <div>Length: {lengthSec.toFixed(2)}s</div>
-      <div>Selected: {selectedSize}</div>
+      <div>
+        Selected: {selectedSize}
+        {lastSelected && (
+          <span>
+            {' '}(
+            {lastSelected.isRest ? 'rest' : `${lastSelected.note}${lastSelected.octave}`}
+            {' d='}
+            {lastSelected.durationDen}
+            {lastSelected.dotted ? '.' : ''}
+            )
+          </span>
+        )}
+      </div>
       <div className="flex gap-1 ml-2">
         <button className="border px-1" onClick={copySel}>Copy</button>
         <button className="border px-1" onClick={cutSel}>Cut</button>
@@ -64,11 +78,11 @@ const TopControls: React.FC<Props> = ({
     </div>
     <button
       className="border px-2 ml-auto"
-      onClick={()=>setDark(!dark)}
+      onClick={() => setDark(!dark)}
       aria-label="Toggle theme"
       title="Toggle theme"
     >
-      {dark ? '🌞' : '🌙'}
+      {dark ? <IconSun size={20} /> : <IconMoon size={20} />}
     </button>
   </div>
 );


### PR DESCRIPTION
## Summary
- switch playback controls and theme toggle to Tabler icons
- show last selected note details and drop "pause" label from rests
- set Morse mode defaults for C-only scale and adjusted timings

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be1ab563a88329b85a64831c93bcb0