### PR TITLE
Improve editor controls and scrolling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -281,7 +281,7 @@ const App:React.FC = () => {
   return (
     <div className="min-h-screen flex flex-col text-xs md:text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
       {/* Top controls */}
-        <TopControls
+      <TopControls
           name={name}
           setName={setName}
           bpm={bpm}
@@ -298,6 +298,7 @@ const App:React.FC = () => {
           cutSel={cutSel}
           pasteClip={pasteClip}
           delSel={delSel}
+          clearAll={clearAll}
           clipboardLength={clipboard.length}
           dark={dark}
           setDark={setDark}
@@ -316,6 +317,7 @@ const App:React.FC = () => {
         playing={playing}
         playTick={playTick}
         onKeyPress={onKeyPress}
+        insertRest={insertRest}
       />
 
       {/* Under keyboard toolbar */}
@@ -324,8 +326,6 @@ const App:React.FC = () => {
         setNextLen={setNextLen}
         nextDot={nextDot}
         setNextDot={setNextDot}
-        insertRest={insertRest}
-        clearAll={clearAll}
         goToStart={goToStart}
         togglePlay={togglePlay}
         goToEnd={goToEnd}

--- a/src/components/InsertControls.tsx
+++ b/src/components/InsertControls.tsx
@@ -6,6 +6,7 @@ import {
   IconPlayerPause,
   IconPlayerSkipForward,
   IconRepeat,
+  IconKeyboard,
 } from '@tabler/icons-react';
 
 interface Props {
@@ -13,8 +14,6 @@ interface Props {
   setNextLen: (d: Den) => void;
   nextDot: boolean;
   setNextDot: (v: boolean) => void;
-  insertRest: () => void;
-  clearAll: () => void;
   goToStart: () => void;
   togglePlay: () => void;
   goToEnd: () => void;
@@ -27,7 +26,7 @@ interface Props {
 
 const InsertControls: React.FC<Props> = ({
   nextLen, setNextLen, nextDot, setNextDot,
-  insertRest, clearAll, goToStart, togglePlay, goToEnd,
+  goToStart, togglePlay, goToEnd,
   loop, setLoop, playing, keyboardMode, setKeyboardMode
 }) => (
   <div className="flex flex-wrap gap-2 p-2 items-center text-xs border-b">
@@ -40,8 +39,6 @@ const InsertControls: React.FC<Props> = ({
     <label className="flex items-center gap-1">
       <input type="checkbox" checked={nextDot} onChange={e=>setNextDot(e.target.checked)} /> dotted
     </label>
-    <button className="border px-1" onClick={insertRest}>+ Pause</button>
-    <button className="border px-1" onClick={clearAll}>Clear</button>
     <div className="flex items-center gap-2 ml-2">
       <button
         className="p-1"
@@ -78,7 +75,8 @@ const InsertControls: React.FC<Props> = ({
       </button>
     </div>
     <label className="mt-2 md:ml-auto flex items-center gap-1 w-full md:w-auto justify-end">
-      <input type="checkbox" checked={keyboardMode} onChange={e=>setKeyboardMode(!!e.target.checked)} /> Keyboard mode
+      <input type="checkbox" checked={keyboardMode} onChange={e=>setKeyboardMode(!!e.target.checked)} />
+      <IconKeyboard size={20} />
       <span className="italic">QWERTYUIOP[] = C5..B5, Space=pause</span>
     </label>
   </div>

--- a/src/components/Keyboard.tsx
+++ b/src/components/Keyboard.tsx
@@ -13,10 +13,18 @@ const Keyboard: React.FC<Props> = ({ keys, colWidth, onKeyPress }) => (
       <div
         key={k.index}
         onClick={() => onKeyPress(k)}
-        className={`absolute flex items-end justify-center cursor-pointer box-border ${k.isBlack ? 'bg-black text-white' : 'bg-white border'}`}
+        className={`absolute flex items-end justify-center cursor-pointer box-border ${k.isBlack ? 'bg-black' : 'bg-white border'}`}
         style={{left: k.index*colWidth, width: colWidth, height: '100%'}}
       >
-        {!k.isBlack && <span className="text-xs text-gray-800">{k.label}</span>}
+        <span
+          className={`text-xs mb-1 ${
+            k.isBlack
+              ? 'px-1 rounded bg-white text-black'
+              : 'text-gray-800'
+          }`}
+        >
+          {k.label}
+        </span>
       </div>
     ))}
   </div>

--- a/src/components/MorseControls.tsx
+++ b/src/components/MorseControls.tsx
@@ -55,16 +55,12 @@ const MorseControls: React.FC<Props> = ({ onAdd }) => {
           <select className="border" value={dotLen} onChange={e=>setDotLen(parseInt(e.target.value) as Den)}>
             {NEXT_DENS.map(n => <option key={n} value={n}>{n}</option>)}
           </select>
-        </label>
-        <label className="flex items-center gap-1">
           <input type="checkbox" checked={dotDot} onChange={e=>setDotDot(e.target.checked)} /> dotted
         </label>
         <label className="flex items-center gap-1">Dash
           <select className="border" value={dashLen} onChange={e=>setDashLen(parseInt(e.target.value) as Den)}>
             {NEXT_DENS.map(n => <option key={n} value={n}>{n}</option>)}
           </select>
-        </label>
-        <label className="flex items-center gap-1">
           <input type="checkbox" checked={dashDot} onChange={e=>setDashDot(e.target.checked)} /> dotted
         </label>
         <label className="flex items-center gap-1">Symbol gap
@@ -72,8 +68,6 @@ const MorseControls: React.FC<Props> = ({ onAdd }) => {
             <option>None</option>
             {NEXT_DENS.map(n => <option key={n} value={n}>{n}</option>)}
           </select>
-        </label>
-        <label className="flex items-center gap-1">
           <input type="checkbox" checked={symDot} onChange={e=>setSymDot(e.target.checked)} /> dotted
         </label>
         <label className="flex items-center gap-1">Letter gap
@@ -81,8 +75,6 @@ const MorseControls: React.FC<Props> = ({ onAdd }) => {
             <option>None</option>
             {NEXT_DENS.map(n => <option key={n} value={n}>{n}</option>)}
           </select>
-        </label>
-        <label className="flex items-center gap-1">
           <input type="checkbox" checked={letDot} onChange={e=>setLetDot(e.target.checked)} /> dotted
         </label>
         <label className="flex items-center gap-1">Word gap
@@ -90,8 +82,6 @@ const MorseControls: React.FC<Props> = ({ onAdd }) => {
             <option>None</option>
             {NEXT_DENS.map(n => <option key={n} value={n}>{n}</option>)}
           </select>
-        </label>
-        <label className="flex items-center gap-1">
           <input type="checkbox" checked={wordDot} onChange={e=>setWordDot(e.target.checked)} /> dotted
         </label>
         <label className="col-span-2 flex items-center gap-1">Scale

--- a/src/components/PianoRoll.tsx
+++ b/src/components/PianoRoll.tsx
@@ -19,6 +19,7 @@ interface Props {
   playing: boolean;
   playTick: number;
   onKeyPress: (k: KeyDef) => void;
+  insertRest: () => void;
 }
 
 const PianoRoll: React.FC<Props> = ({
@@ -32,6 +33,7 @@ const PianoRoll: React.FC<Props> = ({
   playing,
   playTick,
   onKeyPress,
+  insertRest,
 }) => {
   const gridRef = useRef<HTMLDivElement>(null);
   const gridContentRef = useRef<HTMLDivElement>(null);
@@ -55,11 +57,11 @@ const PianoRoll: React.FC<Props> = ({
   useEffect(() => {
     const t = playing ? playTick : cursorTick;
     const cont = gridRef.current;
-    const contentH = gridHeight;
+    const contentH = gridContentRef.current?.scrollHeight ?? gridHeight;
     if (cont) {
       const maxScroll = Math.max(0, contentH - cont.clientHeight);
       const target = contentH - t * pxPerTick - cont.clientHeight / 2;
-      cont.scrollTop = Math.max(0, Math.min(target, maxScroll));
+      cont.scrollTo({ top: Math.max(0, Math.min(target, maxScroll)) });
     }
   }, [playTick, cursorTick, playing, gridHeight]);
 
@@ -74,7 +76,7 @@ const PianoRoll: React.FC<Props> = ({
     <div className="flex flex-col w-full items-start">
       <div
         ref={gridRef}
-        className="w-full overflow-y-scroll h-72 md:h-[520px] flex flex-col items-start justify-end"
+        className="w-full overflow-y-auto h-72 md:h-[520px] flex flex-col items-start justify-end"
         onClick={onGridClick}
       >
         <div
@@ -143,7 +145,18 @@ const PianoRoll: React.FC<Props> = ({
             />
           </div>
         </div>
-      <Keyboard keys={keys} colWidth={colWidth} onKeyPress={onKeyPress} />
+      <div className="flex flex-col" style={{ width: gridWidth }}>
+        <Keyboard keys={keys} colWidth={colWidth} onKeyPress={onKeyPress} />
+        <button
+          className="border mt-2 py-2 w-full"
+          onClick={(e) => {
+            e.stopPropagation();
+            insertRest();
+          }}
+        >
+          + Pause
+        </button>
+      </div>
     </div>
   );
 };

--- a/src/components/TopControls.tsx
+++ b/src/components/TopControls.tsx
@@ -21,6 +21,7 @@ interface Props {
   cutSel: () => void;
   pasteClip: () => void;
   delSel: () => void;
+  clearAll: () => void;
   clipboardLength: number;
   dark: boolean;
   setDark: (v: boolean) => void;
@@ -30,7 +31,7 @@ interface Props {
 const TopControls: React.FC<Props> = ({
   name, setName, bpm, setBpm, defDen, setDefDen, defOct, setDefOct,
   notesLength, totalTicks, lengthSec, selectedSize,
-  copySel, cutSel, pasteClip, delSel, clipboardLength,
+  copySel, cutSel, pasteClip, delSel, clearAll, clipboardLength,
   dark, setDark, lastSelected
 }) => (
   <div className="flex gap-4 p-2 items-center flex-wrap text-xs">
@@ -74,10 +75,11 @@ const TopControls: React.FC<Props> = ({
         <button className="border px-1" onClick={cutSel}>Cut</button>
         <button className="border px-1" disabled={!clipboardLength} onClick={pasteClip}>Paste</button>
         <button className="border px-1" onClick={delSel}>Delete</button>
+        <button className="border px-1" onClick={clearAll}>Clear</button>
       </div>
     </div>
     <button
-      className="border px-2 ml-auto"
+      className="px-2 ml-auto"
       onClick={() => setDark(!dark)}
       aria-label="Toggle theme"
       title="Toggle theme"


### PR DESCRIPTION
## Summary
- Keep playhead in view and restore scrolling in piano roll with a dedicated pause button below the keyboard
- Streamline toolbar: move clear beside delete, add keyboard icon toggle, and label black piano keys
- Restructure Morse module options into a compact grid layout

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be22c530a88329bfd603a99e56b91c