### PR TITLE
feat: enhance morse controls

### DIFF
--- a/src/components/MorseControls.tsx
+++ b/src/components/MorseControls.tsx
@@ -21,6 +21,7 @@ const MorseControls: React.FC<Props> = ({ onAdd }) => {
   const [scale, setScale] = useState('Custom');
   const [customScale, setCustomScale] = useState('C');
   const [morseOct, setMorseOct] = useState(4);
+  const [scaleBySymbol, setScaleBySymbol] = useState(false);
   const scaleIndex = useRef(0);
 
   function addMorse() {
@@ -40,7 +41,8 @@ const MorseControls: React.FC<Props> = ({ onAdd }) => {
       letDot,
       wordGap,
       wordDot,
-      startIndex: scaleIndex.current
+      startIndex: scaleIndex.current,
+      scaleBySymbol
     });
     onAdd(events);
     scaleIndex.current = nextIndex;
@@ -84,6 +86,9 @@ const MorseControls: React.FC<Props> = ({ onAdd }) => {
           </select>
           <input type="checkbox" checked={wordDot} onChange={e=>setWordDot(e.target.checked)} /> dotted
         </label>
+        <label className="flex items-center gap-1">Octave
+          <input className="border w-12" type="number" min={4} max={7} value={morseOct} onChange={e=>setMorseOct(parseInt(e.target.value))} />
+        </label>
         <label className="col-span-2 flex items-center gap-1">Scale
           <select className="border" value={scale} onChange={e=>setScale(e.target.value)}>
             {Object.keys(SCALES).map(s => <option key={s} value={s}>{s}</option>)}
@@ -91,12 +96,12 @@ const MorseControls: React.FC<Props> = ({ onAdd }) => {
           </select>
         </label>
         {scale === 'Custom' && (
-          <label className="col-span-2 flex items-center gap-1">Notes
-            <input className="border" value={customScale} onChange={e=>setCustomScale(e.target.value)} placeholder="C,C#,D" />
+          <label className="col-span-2 flex flex-col gap-1">Notes
+            <textarea className="border p-1 w-full h-24" value={customScale} onChange={e=>setCustomScale(e.target.value)} placeholder="C,C#,D" />
           </label>
         )}
-        <label className="col-span-2 flex items-center gap-1">Octave
-          <input className="border w-12" type="number" min={4} max={7} value={morseOct} onChange={e=>setMorseOct(parseInt(e.target.value))} />
+        <label className="col-span-2 flex items-center gap-1">
+          <input type="checkbox" checked={scaleBySymbol} onChange={e=>setScaleBySymbol(e.target.checked)} /> Scale per symbol
         </label>
       </div>
       <button className="border px-2 mt-2" onClick={addMorse}>Add Morse</button>

--- a/src/morse.ts
+++ b/src/morse.ts
@@ -19,6 +19,7 @@ export interface MorseOptions {
   wordGap: Den | 'None';
   wordDot: boolean;
   startIndex: number;
+  scaleBySymbol: boolean;
 }
 
 export function morseToEvents(text: string, opts: MorseOptions): { events: NoteEvent[]; nextIndex: number } {
@@ -37,18 +38,35 @@ export function morseToEvents(text: string, opts: MorseOptions): { events: NoteE
     }
     const code = MORSE[ch];
     if (!code) continue;
-    const noteName = scaleNotes[idx % scaleNotes.length];
-    const keyIndex = KEYS.findIndex(k => k.name === noteName && k.octave === opts.morseOct);
-    idx++;
-    for (let j = 0; j < code.length; j++) {
-      const sym = code[j];
-      if (sym === '.') {
-        events.push({ id: crypto.randomUUID(), isRest: false, keyIndex, note: noteName, octave: opts.morseOct, durationDen: opts.dotLen, dotted: opts.dotDot });
-      } else {
-        events.push({ id: crypto.randomUUID(), isRest: false, keyIndex, note: noteName, octave: opts.morseOct, durationDen: opts.dashLen, dotted: opts.dashDot });
+    if (opts.scaleBySymbol) {
+      for (let j = 0; j < code.length; j++) {
+        const noteName = scaleNotes[idx % scaleNotes.length];
+        const keyIndex = KEYS.findIndex(k => k.name === noteName && k.octave === opts.morseOct);
+        idx++;
+        const sym = code[j];
+        if (sym === '.') {
+          events.push({ id: crypto.randomUUID(), isRest: false, keyIndex, note: noteName, octave: opts.morseOct, durationDen: opts.dotLen, dotted: opts.dotDot });
+        } else {
+          events.push({ id: crypto.randomUUID(), isRest: false, keyIndex, note: noteName, octave: opts.morseOct, durationDen: opts.dashLen, dotted: opts.dashDot });
+        }
+        if (j < code.length - 1 && opts.symGap !== 'None') {
+          events.push({ id: crypto.randomUUID(), isRest: true, durationDen: opts.symGap, dotted: opts.symDot });
+        }
       }
-      if (j < code.length - 1 && opts.symGap !== 'None') {
-        events.push({ id: crypto.randomUUID(), isRest: true, durationDen: opts.symGap, dotted: opts.symDot });
+    } else {
+      const noteName = scaleNotes[idx % scaleNotes.length];
+      const keyIndex = KEYS.findIndex(k => k.name === noteName && k.octave === opts.morseOct);
+      idx++;
+      for (let j = 0; j < code.length; j++) {
+        const sym = code[j];
+        if (sym === '.') {
+          events.push({ id: crypto.randomUUID(), isRest: false, keyIndex, note: noteName, octave: opts.morseOct, durationDen: opts.dotLen, dotted: opts.dotDot });
+        } else {
+          events.push({ id: crypto.randomUUID(), isRest: false, keyIndex, note: noteName, octave: opts.morseOct, durationDen: opts.dashLen, dotted: opts.dashDot });
+        }
+        if (j < code.length - 1 && opts.symGap !== 'None') {
+          events.push({ id: crypto.randomUUID(), isRest: true, durationDen: opts.symGap, dotted: opts.symDot });
+        }
       }
     }
     if (i < up.length - 1) {


### PR DESCRIPTION
## Summary
- rearrange Morse controls UI, move octave next to word gap
- allow custom scale notes via larger textarea and optional per-symbol scaling
- support per-symbol note scaling in `morseToEvents`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be268befcc8329850501861ccf579c