### PR TITLE
fix: keep piano roll playhead in view

### DIFF
--- a/src/components/PianoRoll.tsx
+++ b/src/components/PianoRoll.tsx
@@ -61,7 +61,7 @@ const PianoRoll: React.FC<Props> = ({
     if (cont) {
       const maxScroll = Math.max(0, contentH - cont.clientHeight);
       const target = contentH - t * pxPerTick - cont.clientHeight / 2;
-      cont.scrollTo({ top: Math.max(0, Math.min(target, maxScroll)) });
+      cont.scrollTop = Math.max(0, Math.min(target, maxScroll));
     }
   }, [playTick, cursorTick, playing, gridHeight]);
 


### PR DESCRIPTION
## Summary
- adjust piano roll auto-scroll to update `scrollTop`
- inline scrollTop calculation for clarity

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be2ea3506c8329ab0c59448d58409a