### PR TITLE
feat: add interleave module

### DIFF
--- a/src/components/InterleaveControls.tsx
+++ b/src/components/InterleaveControls.tsx
@@ -1,0 +1,26 @@
+import React, { useState } from 'react';
+
+interface Props {
+  onInterleave: (rtttl: string) => void;
+}
+
+const InterleaveControls: React.FC<Props> = ({ onInterleave }) => {
+  const [text, setText] = useState('');
+
+  return (
+    <div className="flex flex-col flex-1">
+      <div className="font-bold">Interleave</div>
+      <textarea
+        className="border p-1 mt-1 flex-1"
+        value={text}
+        onChange={e => setText(e.target.value)}
+        placeholder="RTTTL string"
+      />
+      <button className="border px-2 mt-2" onClick={() => onInterleave(text)}>
+        Interleave
+      </button>
+    </div>
+  );
+};
+
+export default InterleaveControls;

--- a/src/components/MorseControls.tsx
+++ b/src/components/MorseControls.tsx
@@ -62,7 +62,7 @@ const MorseControls: React.FC<Props> = ({ onAdd }) => {
   }
 
   return (
-    <div className="flex-1 md:w-1/2 p-2 flex flex-col md:border-l mt-2 md:mt-0">
+    <div className="flex flex-col flex-1">
       <div className="font-bold">Morse Mode</div>
       <textarea className="border p-1 mt-1 flex-1" value={morseText} onChange={e=>setMorseText(e.target.value)} />
       <div className="grid grid-cols-2 gap-1 text-xs mt-1">


### PR DESCRIPTION
## Summary
- add interleave module for blending RTTTL notes with the current roll
- show Morse and Interleave modules under a tab interface
- adjust Morse controls for new tab container

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bef8e535888329936f69a3a650a733