### PR TITLE
feat: allow reverse and flip to act on selected notes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -197,19 +197,30 @@ const App:React.FC = () => {
   },[selected]);
 
   function reverseNotes(){
-    setNotes(prev => [...prev].reverse());
-    setSelected(new Set());
-    setLastSelected(null);
+    setNotes(prev => {
+      if(selected.size){
+        const sel = prev.filter(n => selected.has(n.id)).reverse();
+        return prev.map(n => selected.has(n.id) ? sel.shift()! : n);
+      }
+      return [...prev].reverse();
+    });
+    if(!selected.size){
+      setSelected(new Set());
+      setLastSelected(null);
+    }
   }
 
   function flipHorizontal(){
     setNotes(prev => prev.map(n => {
+      if(selected.size && !selected.has(n.id)) return n;
       if(n.isRest) return n;
       const ni = KEYS.length - 1 - n.keyIndex!;
       return {...n,keyIndex:ni,note:KEYS[ni].name,octave:KEYS[ni].octave};
     }));
-    setSelected(new Set());
-    setLastSelected(null);
+    if(!selected.size){
+      setSelected(new Set());
+      setLastSelected(null);
+    }
   }
 
   function squashRests(){


### PR DESCRIPTION
## Summary
- reverse only selected notes or entire sequence when none are selected
- flip note pitches horizontally only within selection or globally when no selection

## Testing
- `npx --yes vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68bf64d12d3c832994186ef1ba1a69d0