### PR TITLE
feat: add RTTTL Morse decoder

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import PianoRoll from "./components/PianoRoll";
 import InsertControls from "./components/InsertControls";
 import RTTTLControls from "./components/RTTTLControls";
 import MorseControls from "./components/MorseControls";
+import MorseDecodeControls from "./components/MorseDecodeControls";
 import SpeechControls from "./components/SpeechControls";
 import InterleaveControls from "./components/InterleaveControls";
 import { parseRTTTL, generateRTTTL } from "./rtttl";
@@ -40,7 +41,7 @@ const App:React.FC = () => {
   const [loop,setLoop] = useState(false);
   const [rtttl,setRtttl] = useState('Tune:d=8,o=5,b=170:');
   const skipParseRef = useRef(false);
-  const [extraTab, setExtraTab] = useState<'morse'|'speech'|'interleave'>('morse');
+  const [extraTab, setExtraTab] = useState<'morse'|'speech'|'interleave'|'decode'>('morse');
 
   // Derived
   const noteWithTiming = notes.reduce<{ev:NoteEvent;startTick:number;durTicks:number}[]>((arr: {ev:NoteEvent;startTick:number;durTicks:number}[], ev: NoteEvent)=>{
@@ -489,6 +490,10 @@ const App:React.FC = () => {
               className={`px-2 ${extraTab==='interleave' ? 'font-bold border-b-2' : ''}`}
               onClick={()=>setExtraTab('interleave')}
             >Interleave</button>
+            <button
+              className={`px-2 ${extraTab==='decode' ? 'font-bold border-b-2' : ''}`}
+              onClick={()=>setExtraTab('decode')}
+            >Morse Decode</button>
           </div>
           <div className="p-2 flex-1 overflow-auto">
             {extraTab==='morse' && (
@@ -499,6 +504,9 @@ const App:React.FC = () => {
             )}
             {extraTab==='interleave' && (
               <InterleaveControls onInterleave={interleaveRTTTL} />
+            )}
+            {extraTab==='decode' && (
+              <MorseDecodeControls />
             )}
           </div>
         </div>

--- a/src/components/MorseDecodeControls.tsx
+++ b/src/components/MorseDecodeControls.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from 'react';
+import { parseRTTTL } from '../rtttl';
+import { ticksFromDen } from '../music';
+import { eventsToMorse } from '../morse';
+
+const MorseDecodeControls: React.FC = () => {
+  const [text, setText] = useState('');
+  const [morse, setMorse] = useState('');
+  const [decoded, setDecoded] = useState('');
+
+  function decode(){
+    try{
+      const song = parseRTTTL(text, 8, 5, 120);
+      const dot = ticksFromDen(song.defDen, false);
+      const res = eventsToMorse(song.notes, dot);
+      setMorse(res.code);
+      setDecoded(res.text);
+    }catch{
+      setMorse('');
+      setDecoded('');
+    }
+  }
+
+  return (
+    <div className="flex flex-col flex-1">
+      <div className="font-bold">Morse Decoder</div>
+      <textarea className="border p-1 mt-1 flex-1" value={text} onChange={e=>setText(e.target.value)} placeholder="RTTTL string" />
+      <button className="border px-2 mt-2" onClick={decode}>Decode</button>
+      {morse && (
+        <div className="mt-2 text-sm">
+          <div className="font-bold">Morse</div>
+          <div className="border p-1 whitespace-pre-wrap font-mono">{morse}</div>
+          <div className="font-bold mt-2">Text</div>
+          <div className="border p-1 whitespace-pre-wrap">{decoded}</div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MorseDecodeControls;


### PR DESCRIPTION
## Summary
- add Morse decoder tab to decode RTTTL duration sequences into text
- implement eventsToMorse utility for converting note events to Morse code
- include UI component for decoding and displaying Morse and text

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c154f304688329881bb08046efb659