### PR TITLE
fix: derive Morse dot length from events

### DIFF
--- a/src/components/MorseDecodeControls.tsx
+++ b/src/components/MorseDecodeControls.tsx
@@ -11,7 +11,9 @@ const MorseDecodeControls: React.FC = () => {
   function decode(){
     try{
       const song = parseRTTTL(text, 8, 5, 120);
-      const dot = ticksFromDen(song.defDen, false);
+      const dot = song.notes.length
+        ? Math.min(...song.notes.map(ev => ticksFromDen(ev.durationDen, ev.dotted)))
+        : ticksFromDen(song.defDen, false);
       const res = eventsToMorse(song.notes, dot);
       setMorse(res.code);
       setDecoded(res.text);


### PR DESCRIPTION
## Summary
- infer dot length from shortest RTTTL event instead of header default

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1723abdb48329a877d3ce266ee394