### PR TITLE
fix: avoid clamping Morse dot length

### DIFF
--- a/src/components/MorseDecodeControls.tsx
+++ b/src/components/MorseDecodeControls.tsx
@@ -9,12 +9,10 @@ function gcd(a:number,b:number){
 }
 
 function baseDot(notes:NoteEvent[], defDen:Den){
-  const base = ticksFromDen(defDen,false);
-  if(!notes.length) return base;
-  const g = notes
+  if(!notes.length) return ticksFromDen(defDen,false);
+  return notes
     .map(ev=>ticksFromDen(ev.durationDen,ev.dotted))
     .reduce((a,b)=>gcd(a,b));
-  return g<base?g:base;
 }
 
 const MorseDecodeControls: React.FC = () => {


### PR DESCRIPTION
## Summary
- avoid clamping Morse dot length to default duration by returning GCD of event ticks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c17a27071c8329b341760725892971