### PR TITLE
fix: clamp Morse dot length to smallest unit

### DIFF
--- a/src/components/MorseDecodeControls.tsx
+++ b/src/components/MorseDecodeControls.tsx
@@ -9,10 +9,12 @@ function gcd(a:number,b:number){
 }
 
 function baseDot(notes:NoteEvent[], defDen:Den){
-  if(!notes.length) return ticksFromDen(defDen,false);
-  return notes
+  const def = ticksFromDen(defDen,false);
+  if(!notes.length) return def;
+  const g = notes
     .map(ev=>ticksFromDen(ev.durationDen,ev.dotted))
     .reduce((a,b)=>gcd(a,b));
+  return Math.min(def,g);
 }
 
 const MorseDecodeControls: React.FC = () => {


### PR DESCRIPTION
## Summary
- clamp derived Morse dot length to default denominator when GCD exceeds it

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c19f0f92588329961a342a5b8f421f