### PR TITLE
feat: allow decoder to customize Morse timing

### DIFF
--- a/src/components/MorseDecodeControls.tsx
+++ b/src/components/MorseDecodeControls.tsx
@@ -1,21 +1,45 @@
 import React, { useState } from 'react';
 import { parseRTTTL } from '../rtttl';
-import { ticksFromDen } from '../music';
+import { ticksFromDen, DEFAULT_DENS, Den, NoteEvent } from '../music';
 import { eventsToMorse } from '../morse';
 
 const MorseDecodeControls: React.FC = () => {
   const [text, setText] = useState('');
   const [morse, setMorse] = useState('');
   const [decoded, setDecoded] = useState('');
+  const [dotLen, setDotLen] = useState<Den>(8);
+  const [dashLen, setDashLen] = useState<Den>(4);
 
-  function decode(){
-    try{
+  function guessLengths(notes: NoteEvent[]): { dot: Den; dash: Den } {
+    const counts: Record<Den, number> = { 1: 0, 2: 0, 4: 0, 8: 0, 16: 0, 32: 0 };
+    notes.filter(n => !n.isRest).forEach(n => {
+      counts[n.durationDen]++;
+    });
+    const used = Object.entries(counts)
+      .filter(([, c]) => c > 0)
+      .sort((a, b) => b[1] - a[1]);
+    const dot = used[0] ? (parseInt(used[0][0]) as Den) : 8;
+    const dashEntry = used.find(([d]) => parseInt(d) !== dot);
+    const dash = dashEntry ? (parseInt(dashEntry[0]) as Den) : dot;
+    return { dot, dash };
+  }
+
+  function decode(opts?: { dot?: Den; dash?: Den; guess?: boolean }) {
+    try {
       const song = parseRTTTL(text, 8, 5, 120);
-      const dot = ticksFromDen(song.defDen, false);
-      const res = eventsToMorse(song.notes, dot);
+      let d = opts?.dot ?? dotLen;
+      let da = opts?.dash ?? dashLen;
+      if (opts?.guess) {
+        const g = guessLengths(song.notes);
+        d = g.dot;
+        da = g.dash;
+        setDotLen(d);
+        setDashLen(da);
+      }
+      const res = eventsToMorse(song.notes, ticksFromDen(d, false), ticksFromDen(da, false));
       setMorse(res.code);
       setDecoded(res.text);
-    }catch{
+    } catch {
       setMorse('');
       setDecoded('');
     }
@@ -25,7 +49,33 @@ const MorseDecodeControls: React.FC = () => {
     <div className="flex flex-col flex-1">
       <div className="font-bold">Morse Decoder</div>
       <textarea className="border p-1 mt-1 flex-1" value={text} onChange={e=>setText(e.target.value)} placeholder="RTTTL string" />
-      <button className="border px-2 mt-2" onClick={decode}>Decode</button>
+      <div className="flex gap-2 mt-2 items-center text-sm">
+        <label>
+          Dot:
+          <select className="border ml-1" value={dotLen} onChange={e=>{
+            const val = parseInt(e.target.value) as Den;
+            setDotLen(val);
+            decode({ dot: val });
+          }}>
+            {DEFAULT_DENS.map(d => (
+              <option key={d} value={d}>{d}</option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Dash:
+          <select className="border ml-1" value={dashLen} onChange={e=>{
+            const val = parseInt(e.target.value) as Den;
+            setDashLen(val);
+            decode({ dash: val });
+          }}>
+            {DEFAULT_DENS.map(d => (
+              <option key={d} value={d}>{d}</option>
+            ))}
+          </select>
+        </label>
+        <button className="border px-2 ml-auto" onClick={()=>decode({guess:true})}>Decode</button>
+      </div>
       {morse && (
         <div className="mt-2 text-sm">
           <div className="font-bold">Morse</div>

--- a/src/morse.ts
+++ b/src/morse.ts
@@ -96,7 +96,7 @@ const REV_MORSE: Record<string,string> = Object.fromEntries(
   Object.entries(MORSE).map(([k,v]) => [v,k])
 );
 
-export function eventsToMorse(events: NoteEvent[], dotTicks: number): { code: string; text: string } {
+export function eventsToMorse(events: NoteEvent[], dotTicks: number, dashTicks: number): { code: string; text: string } {
   const wordsCode: string[][] = [[]];
   const wordsText: string[][] = [[]];
   let currentSymbols = '';
@@ -108,10 +108,13 @@ export function eventsToMorse(events: NoteEvent[], dotTicks: number): { code: st
     currentSymbols='';
   }
   events.forEach(ev => {
-    const units = Math.round(ticksFromDen(ev.durationDen, ev.dotted) / dotTicks);
+    const t = ticksFromDen(ev.durationDen, ev.dotted);
     if (!ev.isRest) {
-      if (units <= 2) currentSymbols += '.'; else currentSymbols += '-';
+      const diffDot = Math.abs(t - dotTicks);
+      const diffDash = Math.abs(t - dashTicks);
+      if (diffDot <= diffDash) currentSymbols += '.'; else currentSymbols += '-';
     } else {
+      const units = Math.round(t / dotTicks);
       if (units >= 7) {
         flushLetter();
         wordsCode.push([]);


### PR DESCRIPTION
## Summary
- add dot and dash length dropdowns to Morse decoder and reparse on change
- enable Morse translation with separate dot and dash tick lengths

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1a95238d88329b4de704dfe146e49