### PR TITLE
feat: add realtime keyboard recording

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -108,7 +108,14 @@ const App:React.FC = () => {
   }
 
   useEffect(()=>{
-    if(!realtime){
+    if(!keyboardMode){
+      setRealtime(false);
+      pressedKeyRef.current = null;
+    }
+  },[keyboardMode]);
+
+  useEffect(()=>{
+    if(!realtime || !keyboardMode){
       pressedKeyRef.current = null;
       return;
     }
@@ -123,7 +130,7 @@ const App:React.FC = () => {
       }
     }, intervalMs);
     return ()=>clearInterval(id);
-  },[realtime,nextLen,nextDot,tickSec]);
+  },[realtime,keyboardMode,nextLen,nextDot,tickSec]);
 
   // Clear
   function clearAll(){

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,10 +32,12 @@ const App:React.FC = () => {
   const [cursorTick,setCursorTick] = useState(0);
   const cursorRef = useRef(0);
   useEffect(()=>{ cursorRef.current = cursorTick; },[cursorTick]);
+  const pressedKeyRef = useRef<KeyDef | null>(null);
   const updateCursor = (tick:number) => { cursorRef.current = tick; setCursorTick(tick); };
   const [nextLen,setNextLen] = useState<Den>(8);
   const [nextDot,setNextDot] = useState(false);
   const [keyboardMode,setKeyboardMode] = useState(false);
+  const [realtime,setRealtime] = useState(false);
   const [playing,setPlaying] = useState(false);
   const [playTick,setPlayTick] = useState(0);
   const [loop,setLoop] = useState(false);
@@ -91,14 +93,37 @@ const App:React.FC = () => {
 
   // Keyboard click
   function onKeyPress(k:KeyDef){
-    insertEvent({id:crypto.randomUUID(),isRest:false,keyIndex:k.index,note:k.name,octave:k.octave,durationDen:nextLen,dotted:nextDot});
-    playTone(k.midi,0.2);
+    if(realtime){
+      playTone(k.midi,0.2);
+      pressedKeyRef.current = k;
+    } else {
+      insertEvent({id:crypto.randomUUID(),isRest:false,keyIndex:k.index,note:k.name,octave:k.octave,durationDen:nextLen,dotted:nextDot});
+      playTone(k.midi,0.2);
+    }
   }
 
   // Pause insert
   function insertRest(){
     insertEvent({id:crypto.randomUUID(),isRest:true,durationDen:nextLen,dotted:nextDot});
   }
+
+  useEffect(()=>{
+    if(!realtime){
+      pressedKeyRef.current = null;
+      return;
+    }
+    const intervalMs = ticksFromDen(nextLen,nextDot) * tickSec * 1000;
+    const id = window.setInterval(()=>{
+      const k = pressedKeyRef.current;
+      if(k){
+        insertEvent({id:crypto.randomUUID(),isRest:false,keyIndex:k.index,note:k.name,octave:k.octave,durationDen:nextLen,dotted:nextDot});
+        pressedKeyRef.current = null;
+      }else{
+        insertRest();
+      }
+    }, intervalMs);
+    return ()=>clearInterval(id);
+  },[realtime,nextLen,nextDot,tickSec]);
 
   // Clear
   function clearAll(){
@@ -277,7 +302,14 @@ const App:React.FC = () => {
   useEffect(()=>{
     function onKey(e: KeyboardEvent){
       if(e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
-      if(e.key===' ' && keyboardMode){ e.preventDefault(); insertRest(); }
+      if(e.key===' ' && keyboardMode){
+        e.preventDefault();
+        if(realtime){
+          pressedKeyRef.current = null;
+        }else{
+          insertRest();
+        }
+      }
       if(keyboardMode){
         const map = 'qwertyuiop[]';
         const idx = map.indexOf(e.key.toLowerCase());
@@ -310,7 +342,7 @@ const App:React.FC = () => {
     }
     window.addEventListener('keydown',onKey);
     return ()=>window.removeEventListener('keydown',onKey);
-  },[selected,notes,cursorTick,nextLen,nextDot,keyboardMode,clipboard,noteWithTiming,totalTicks,selectAll,deselectAll,moveSelectedPitch,adjustSelectedDuration]);
+  },[selected,notes,cursorTick,nextLen,nextDot,keyboardMode,realtime,clipboard,noteWithTiming,totalTicks,selectAll,deselectAll,moveSelectedPitch,adjustSelectedDuration]);
 
   // Playback
   const timeoutsRef = useRef<number[]>([]);
@@ -465,6 +497,8 @@ const App:React.FC = () => {
         playing={playing}
         keyboardMode={keyboardMode}
         setKeyboardMode={setKeyboardMode}
+        realtime={realtime}
+        setRealtime={setRealtime}
         selectedSize={selected.size}
         moveSelectedPitch={moveSelectedPitch}
         adjustSelectedDuration={adjustSelectedDuration}

--- a/src/components/InsertControls.tsx
+++ b/src/components/InsertControls.tsx
@@ -7,6 +7,7 @@ import {
   IconPlayerSkipForward,
   IconRepeat,
   IconKeyboard,
+  IconPlayerRecord,
   IconArrowLeft,
   IconArrowRight,
   IconArrowUp,
@@ -26,6 +27,8 @@ interface Props {
   playing: boolean;
   keyboardMode: boolean;
   setKeyboardMode: (v: boolean) => void;
+  realtime: boolean;
+  setRealtime: (v: boolean) => void;
   selectedSize: number;
   moveSelectedPitch: (d:number) => void;
   adjustSelectedDuration: (d:number) => void;
@@ -35,6 +38,7 @@ const InsertControls: React.FC<Props> = ({
   nextLen, setNextLen, nextDot, setNextDot,
   goToStart, togglePlay, goToEnd,
   loop, setLoop, playing, keyboardMode, setKeyboardMode,
+  realtime, setRealtime,
   selectedSize, moveSelectedPitch, adjustSelectedDuration
 }) => (
   <div className="flex flex-wrap gap-2 p-2 items-center text-xs border-b">
@@ -82,11 +86,24 @@ const InsertControls: React.FC<Props> = ({
         <IconRepeat size={24} />
       </button>
     </div>
-    <label className="mt-2 md:ml-auto flex items-center gap-1 w-full md:w-auto justify-end">
-      <input type="checkbox" checked={keyboardMode} onChange={e=>setKeyboardMode(!!e.target.checked)} />
-      <IconKeyboard size={20} />
-      <span className="italic">QWERTYUIOP[] = C5..B5, Space=pause</span>
-    </label>
+    <div className="mt-2 md:ml-auto flex items-center gap-2 w-full md:w-auto justify-end">
+      <label className="flex items-center gap-1">
+        <input type="checkbox" checked={keyboardMode} onChange={e=>setKeyboardMode(!!e.target.checked)} />
+        <IconKeyboard size={20} />
+        <span className="italic">QWERTYUIOP[] = C5..B5, Space=pause</span>
+      </label>
+      {keyboardMode && (
+        <button
+          className={`p-1 rounded ${realtime ? 'bg-red-500 text-white' : ''}`}
+          onClick={() => setRealtime(!realtime)}
+          aria-pressed={realtime}
+          aria-label="Toggle realtime recording"
+          title="Toggle realtime recording"
+        >
+          <IconPlayerRecord size={20} />
+        </button>
+      )}
+    </div>
     {selectedSize > 0 && (
       <div className="flex w-full justify-center gap-2 mt-2 md:hidden">
         <button className="p-2 border rounded" onClick={()=>moveSelectedPitch(-1)} aria-label="Lower pitch">


### PR DESCRIPTION
## Summary
- add realtime recording mode that inserts rests or notes at each beat
- allow keyboard clicks and QWERTY input to queue notes while recording
- expose record toggle in keyboard controls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c200c44be883298c7472f0481d8874