### PR TITLE
fix: stop realtime recording when keyboard disabled

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -108,7 +108,14 @@ const App:React.FC = () => {
   }
 
   useEffect(()=>{
-    if(!realtime){
+    if(!keyboardMode){
+      setRealtime(false);
+      pressedKeyRef.current = null;
+    }
+  },[keyboardMode]);
+
+  useEffect(()=>{
+    if(!realtime || !keyboardMode){
       pressedKeyRef.current = null;
       return;
     }
@@ -123,7 +130,7 @@ const App:React.FC = () => {
       }
     }, intervalMs);
     return ()=>clearInterval(id);
-  },[realtime,nextLen,nextDot,tickSec]);
+  },[realtime,keyboardMode,nextLen,nextDot,tickSec]);
 
   // Clear
   function clearAll(){


### PR DESCRIPTION
## Summary
- disable realtime recording when keyboard mode toggles off
- guard realtime recording interval with keyboard mode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c32d7d91908329bc153d5788eb6dd7