### PR TITLE
feat: add phone tone module and keypad UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import MorseControls from "./components/MorseControls";
 import MorseDecodeControls from "./components/MorseDecodeControls";
 import SpeechControls from "./components/SpeechControls";
 import InterleaveControls from "./components/InterleaveControls";
+import PhoneControls from "./components/PhoneControls";
 import { parseRTTTL, generateRTTTL } from "./rtttl";
 
 
@@ -43,7 +44,7 @@ const App:React.FC = () => {
   const [loop,setLoop] = useState(false);
   const [rtttl,setRtttl] = useState('Tune:d=8,o=5,b=170:');
   const skipParseRef = useRef(false);
-  const [extraTab, setExtraTab] = useState<'morse'|'speech'|'interleave'|'decode'>('morse');
+  const [extraTab, setExtraTab] = useState<'morse'|'speech'|'interleave'|'decode'|'phone'>('morse');
 
   // Derived
   const noteWithTiming = notes.reduce<{ev:NoteEvent;startTick:number;durTicks:number}[]>((arr: {ev:NoteEvent;startTick:number;durTicks:number}[], ev: NoteEvent)=>{
@@ -535,6 +536,10 @@ const App:React.FC = () => {
               className={`px-2 ${extraTab==='decode' ? 'font-bold border-b-2' : ''}`}
               onClick={()=>setExtraTab('decode')}
             >Morse Decode</button>
+            <button
+              className={`px-2 ${extraTab==='phone' ? 'font-bold border-b-2' : ''}`}
+              onClick={()=>setExtraTab('phone')}
+            >Phone</button>
           </div>
           <div className="p-2 flex-1 overflow-auto">
             {extraTab==='morse' && (
@@ -548,6 +553,9 @@ const App:React.FC = () => {
             )}
             {extraTab==='decode' && (
               <MorseDecodeControls />
+            )}
+            {extraTab==='phone' && (
+              <PhoneControls onAdd={(events)=>events.forEach(insertEvent)} />
             )}
           </div>
         </div>

--- a/src/components/PhoneControls.tsx
+++ b/src/components/PhoneControls.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Den, NoteEvent } from '../music';
+import { dtmfToEvents, blueBoxToEvents, redBoxCoinToEvents, tone2600ToEvents } from '../phone';
+
+interface Props {
+  onAdd: (events: NoteEvent[]) => void;
+}
+
+const PhoneControls: React.FC<Props> = ({ onAdd }) => {
+  const toneDen: Den = 32;
+  const gapDen: Den = 16;
+
+  function addEvents(events: NoteEvent[]) {
+    events.push({ id: crypto.randomUUID(), isRest: true, durationDen: gapDen });
+    onAdd(events);
+  }
+
+  const handleDtmf = (k: string) => addEvents(dtmfToEvents(k, { toneDen }));
+  const handleBlue = (k: string) => addEvents(blueBoxToEvents(k, { toneDen }));
+  const handleRed = (v: 5 | 10 | 25) => addEvents(redBoxCoinToEvents(v, { toneDen, gapDen }));
+  const handle2600 = () => addEvents(tone2600ToEvents(8));
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <div className="font-bold mb-1">DTMF Keypad</div>
+        <div className="grid grid-cols-4 gap-1">
+          {['1','2','3','A','4','5','6','B','7','8','9','C','*','0','#','D'].map(k => (
+            <button key={k} className="border p-2" onClick={() => handleDtmf(k)}>{k}</button>
+          ))}
+        </div>
+      </div>
+      <div>
+        <div className="font-bold mb-1">Blue Box</div>
+        <div className="grid grid-cols-3 gap-1">
+          {['KP','1','2','3','4','5','6','7','8','9','0','ST'].map(k => (
+            <button key={k} className="border p-2" onClick={() => handleBlue(k)}>{k}</button>
+          ))}
+        </div>
+      </div>
+      <div>
+        <div className="font-bold mb-1">Red Box</div>
+        <div className="flex gap-1 flex-wrap">
+          <button className="border p-2" onClick={() => handleRed(5)}>5¢</button>
+          <button className="border p-2" onClick={() => handleRed(10)}>10¢</button>
+          <button className="border p-2" onClick={() => handleRed(25)}>25¢</button>
+          <button className="border p-2" onClick={handle2600}>2600Hz</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PhoneControls;
+

--- a/src/phone.test.ts
+++ b/src/phone.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import {
+  dtmfToEvents,
+  blueBoxToEvents,
+  redBoxCoinToEvents,
+  tone2600ToEvents,
+} from './phone';
+
+describe('phone tone helpers', () => {
+  it('produces two notes for a single DTMF key', () => {
+    const events = dtmfToEvents('1');
+    expect(events).toHaveLength(2);
+    expect(events[0].isRest).toBe(false);
+    expect(events[1].isRest).toBe(false);
+  });
+
+  it('inserts a rest between DTMF keys', () => {
+    const events = dtmfToEvents('12');
+    expect(events).toHaveLength(5);
+    expect(events[2].isRest).toBe(true);
+  });
+
+  it('handles blue box tokens', () => {
+    const events = blueBoxToEvents('KP1ST');
+    // three tokens -> 3 pairs of notes + two rests
+    expect(events).toHaveLength(8);
+  });
+
+  it('creates bursts for red box coin values', () => {
+    const events = redBoxCoinToEvents(10);
+    // 10c -> two bursts -> pair + rest + pair
+    expect(events).toHaveLength(5);
+    expect(events[2].isRest).toBe(true);
+  });
+
+  it('generates single event for 2600 Hz tone', () => {
+    const events = tone2600ToEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0].isRest).toBe(false);
+  });
+});
+

--- a/src/phone.ts
+++ b/src/phone.ts
@@ -1,0 +1,161 @@
+import { Den, NoteEvent, KEYS, KeyDef } from './music';
+import { generateRTTTL } from './rtttl';
+
+// DTMF keypad frequencies (key -> [low, high])
+export const DTMF_FREQS: Record<string, [number, number]> = {
+  '1': [697, 1209],
+  '2': [697, 1336],
+  '3': [697, 1477],
+  'A': [697, 1633],
+  '4': [770, 1209],
+  '5': [770, 1336],
+  '6': [770, 1477],
+  'B': [770, 1633],
+  '7': [852, 1209],
+  '8': [852, 1336],
+  '9': [852, 1477],
+  'C': [852, 1633],
+  '*': [941, 1209],
+  '0': [941, 1336],
+  '#': [941, 1477],
+  'D': [941, 1633],
+};
+
+// Blue box / MF signalling approximations
+export const BLUE_BOX_FREQS: Record<string, [number, number]> = {
+  '1': [700, 900],
+  '2': [700, 1100],
+  '3': [900, 1100],
+  '4': [700, 1300],
+  '5': [900, 1300],
+  '6': [1100, 1300],
+  '7': [700, 1500],
+  '8': [900, 1500],
+  '9': [1100, 1500],
+  '0': [1300, 1500],
+  'KP': [1100, 1700],
+  'ST': [1500, 1700],
+};
+
+const RED_BOX_PAIR: [number, number] = [1700, 2200];
+const TONE_2600 = 2600;
+
+function midiToFreq(midi: number): number {
+  return 440 * Math.pow(2, (midi - 69) / 12);
+}
+
+function nearestKey(freq: number): KeyDef {
+  let best = KEYS[0];
+  let minDiff = Math.abs(midiToFreq(best.midi) - freq);
+  for (const k of KEYS) {
+    const diff = Math.abs(midiToFreq(k.midi) - freq);
+    if (diff < minDiff) {
+      best = k;
+      minDiff = diff;
+    }
+  }
+  return best;
+}
+
+interface ToneOptions {
+  toneDen?: Den;
+  gapDen?: Den;
+}
+
+function pairToEvents(pair: [number, number], toneDen: Den): NoteEvent[] {
+  return pair.map(freq => {
+    const key = nearestKey(freq);
+    return {
+      id: crypto.randomUUID(),
+      isRest: false,
+      keyIndex: key.index,
+      note: key.name,
+      octave: key.octave,
+      durationDen: toneDen,
+    };
+  });
+}
+
+export function dtmfToEvents(keys: string, { toneDen = 32, gapDen = 16 }: ToneOptions = {}): NoteEvent[] {
+  const events: NoteEvent[] = [];
+  const up = keys.toUpperCase();
+  for (let i = 0; i < up.length; i++) {
+    const ch = up[i];
+    const pair = DTMF_FREQS[ch];
+    if (!pair) continue;
+    events.push(...pairToEvents(pair, toneDen));
+    if (i < up.length - 1) {
+      events.push({ id: crypto.randomUUID(), isRest: true, durationDen: gapDen });
+    }
+  }
+  return events;
+}
+
+export function blueBoxToEvents(seq: string, { toneDen = 32, gapDen = 16 }: ToneOptions = {}): NoteEvent[] {
+  const tokens = seq.toUpperCase().match(/KP|ST|[0-9]/g) ?? [];
+  const events: NoteEvent[] = [];
+  tokens.forEach((tok, idx) => {
+    const pair = BLUE_BOX_FREQS[tok];
+    if (!pair) return;
+    events.push(...pairToEvents(pair, toneDen));
+    if (idx < tokens.length - 1) {
+      events.push({ id: crypto.randomUUID(), isRest: true, durationDen: gapDen });
+    }
+  });
+  return events;
+}
+
+export function redBoxCoinToEvents(value: 5 | 10 | 25, { toneDen = 32, gapDen = 32 }: ToneOptions = {}): NoteEvent[] {
+  const bursts = { 5: 1, 10: 2, 25: 5 }[value] ?? 0;
+  const events: NoteEvent[] = [];
+  for (let i = 0; i < bursts; i++) {
+    events.push(...pairToEvents(RED_BOX_PAIR, toneDen));
+    if (i < bursts - 1) {
+      events.push({ id: crypto.randomUUID(), isRest: true, durationDen: gapDen });
+    }
+  }
+  return events;
+}
+
+export function tone2600ToEvents(toneDen: Den = 8): NoteEvent[] {
+  const key = nearestKey(TONE_2600);
+  return [
+    {
+      id: crypto.randomUUID(),
+      isRest: false,
+      keyIndex: key.index,
+      note: key.name,
+      octave: key.octave,
+      durationDen: toneDen,
+    },
+  ];
+}
+
+// Helpers to directly create RTTTL strings
+export function dtmfToRTTTL(name: string, tempo: number, keys: string, opts?: ToneOptions) {
+  const toneDen = opts?.toneDen ?? 32;
+  const defOct = 5;
+  const events = dtmfToEvents(keys, opts);
+  return generateRTTTL(name, toneDen, defOct, tempo, events);
+}
+
+export function blueBoxToRTTTL(name: string, tempo: number, seq: string, opts?: ToneOptions) {
+  const toneDen = opts?.toneDen ?? 32;
+  const defOct = 5;
+  const events = blueBoxToEvents(seq, opts);
+  return generateRTTTL(name, toneDen, defOct, tempo, events);
+}
+
+export function redBoxCoinToRTTTL(name: string, tempo: number, value: 5 | 10 | 25, opts?: ToneOptions) {
+  const toneDen = opts?.toneDen ?? 32;
+  const defOct = 5;
+  const events = redBoxCoinToEvents(value, opts);
+  return generateRTTTL(name, toneDen, defOct, tempo, events);
+}
+
+export function tone2600ToRTTTL(name: string, tempo: number, toneDen: Den = 8) {
+  const defOct = 5;
+  const events = tone2600ToEvents(toneDen);
+  return generateRTTTL(name, toneDen, defOct, tempo, events);
+}
+


### PR DESCRIPTION
## Summary
- generate RTTTL events for DTMF keypad, blue box, red box and 2600 Hz tones
- provide helpers to turn tone sequences into RTTTL strings
- add phone keypad tab to insert DTMF/blue/red box tones into the roll

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3e39250e88329be71405621d79848