### PR TITLE
Add realtime phone tones and modem noise

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -555,7 +555,7 @@ const App:React.FC = () => {
               <MorseDecodeControls />
             )}
             {extraTab==='phone' && (
-              <PhoneControls onAdd={(events)=>events.forEach(insertEvent)} />
+              <PhoneControls onAdd={(events)=>events.forEach(insertEvent)} setBpm={setBpm} />
             )}
           </div>
         </div>

--- a/src/components/PhoneControls.tsx
+++ b/src/components/PhoneControls.tsx
@@ -1,12 +1,25 @@
 import React from 'react';
 import { Den, NoteEvent } from '../music';
-import { dtmfToEvents, blueBoxToEvents, redBoxCoinToEvents, tone2600ToEvents } from '../phone';
+import {
+  dtmfToEvents,
+  blueBoxToEvents,
+  redBoxCoinToEvents,
+  tone2600ToEvents,
+  modemNoiseToEvents,
+  DTMF_FREQS,
+  BLUE_BOX_FREQS,
+  RED_BOX_PAIR,
+  TONE_2600,
+  MODEM_TEMPO,
+} from '../phone';
+import { playFreqs } from '../sound';
 
 interface Props {
   onAdd: (events: NoteEvent[]) => void;
+  setBpm: (tempo: number) => void;
 }
 
-const PhoneControls: React.FC<Props> = ({ onAdd }) => {
+const PhoneControls: React.FC<Props> = ({ onAdd, setBpm }) => {
   const toneDen: Den = 32;
   const gapDen: Den = 16;
 
@@ -15,10 +28,28 @@ const PhoneControls: React.FC<Props> = ({ onAdd }) => {
     onAdd(events);
   }
 
-  const handleDtmf = (k: string) => addEvents(dtmfToEvents(k, { toneDen }));
-  const handleBlue = (k: string) => addEvents(blueBoxToEvents(k, { toneDen }));
-  const handleRed = (v: 5 | 10 | 25) => addEvents(redBoxCoinToEvents(v, { toneDen, gapDen }));
-  const handle2600 = () => addEvents(tone2600ToEvents(8));
+  const handleDtmf = (k: string) => {
+    const pair = DTMF_FREQS[k];
+    if (pair) playFreqs(pair);
+    addEvents(dtmfToEvents(k, { toneDen }));
+  };
+  const handleBlue = (k: string) => {
+    const pair = BLUE_BOX_FREQS[k];
+    if (pair) playFreqs(pair);
+    addEvents(blueBoxToEvents(k, { toneDen }));
+  };
+  const handleRed = (v: 5 | 10 | 25) => {
+    playFreqs(RED_BOX_PAIR);
+    addEvents(redBoxCoinToEvents(v, { toneDen, gapDen }));
+  };
+  const handle2600 = () => {
+    playFreqs([TONE_2600]);
+    addEvents(tone2600ToEvents(8));
+  };
+  const handleModem = () => {
+    setBpm(MODEM_TEMPO);
+    addEvents(modemNoiseToEvents(5, { toneDen }));
+  };
 
   return (
     <div className="flex flex-col gap-4">
@@ -46,6 +77,10 @@ const PhoneControls: React.FC<Props> = ({ onAdd }) => {
           <button className="border p-2" onClick={() => handleRed(25)}>25¢</button>
           <button className="border p-2" onClick={handle2600}>2600Hz</button>
         </div>
+      </div>
+      <div>
+        <div className="font-bold mb-1">Modem</div>
+        <button className="border p-2" onClick={handleModem}>AOL Noise</button>
       </div>
     </div>
   );

--- a/src/phone.test.ts
+++ b/src/phone.test.ts
@@ -4,6 +4,8 @@ import {
   blueBoxToEvents,
   redBoxCoinToEvents,
   tone2600ToEvents,
+  modemNoiseToEvents,
+  MODEM_TEMPO,
 } from './phone';
 
 describe('phone tone helpers', () => {
@@ -37,6 +39,13 @@ describe('phone tone helpers', () => {
     const events = tone2600ToEvents();
     expect(events).toHaveLength(1);
     expect(events[0].isRest).toBe(false);
+  });
+
+  it('generates modem noise events', () => {
+    const events = modemNoiseToEvents();
+    const expected = Math.round((MODEM_TEMPO * 5) / 7.5);
+    expect(events.length).toBeGreaterThan(expected - 5);
+    expect(events.every(e => !e.isRest)).toBe(true);
   });
 });
 

--- a/src/phone.ts
+++ b/src/phone.ts
@@ -37,8 +37,9 @@ export const BLUE_BOX_FREQS: Record<string, [number, number]> = {
   'ST': [1500, 1700],
 };
 
-const RED_BOX_PAIR: [number, number] = [1700, 2200];
-const TONE_2600 = 2600;
+export const RED_BOX_PAIR: [number, number] = [1700, 2200];
+export const TONE_2600 = 2600;
+export const MODEM_TEMPO = 800;
 
 function midiToFreq(midi: number): number {
   return 440 * Math.pow(2, (midi - 69) / 12);
@@ -129,6 +130,24 @@ export function tone2600ToEvents(toneDen: Den = 8): NoteEvent[] {
       durationDen: toneDen,
     },
   ];
+}
+
+export function modemNoiseToEvents(seconds = 5, { toneDen = 32 }: ToneOptions = {}): NoteEvent[] {
+  const noteDurSec = 60 / MODEM_TEMPO * 4 / toneDen;
+  const total = Math.round(seconds / noteDurSec);
+  const events: NoteEvent[] = [];
+  for (let i = 0; i < total; i++) {
+    const key = KEYS[Math.floor(Math.random() * KEYS.length)];
+    events.push({
+      id: crypto.randomUUID(),
+      isRest: false,
+      keyIndex: key.index,
+      note: key.name,
+      octave: key.octave,
+      durationDen: toneDen,
+    });
+  }
+  return events;
 }
 
 // Helpers to directly create RTTTL strings

--- a/src/sound.ts
+++ b/src/sound.ts
@@ -30,3 +30,21 @@ export function playTone(midi: number, dur = 0.15) {
   gain.gain.linearRampToValueAtTime(0.0001, now + dur + 0.01);
   osc.stop(now + dur + 0.02);
 }
+
+export function playFreqs(freqs: number[], dur = 0.15) {
+  const ctx = getAudioContext();
+  const gain = ctx.createGain();
+  gain.connect(ctx.destination);
+  const now = ctx.currentTime;
+  freqs.forEach(f => {
+    const osc = ctx.createOscillator();
+    osc.type = 'sine';
+    osc.frequency.value = f;
+    osc.connect(gain);
+    osc.start(now);
+    osc.stop(now + dur + 0.02);
+  });
+  gain.gain.setValueAtTime(0.2, now);
+  gain.gain.setValueAtTime(0.2, now + dur);
+  gain.gain.linearRampToValueAtTime(0.0001, now + dur + 0.01);
+}


### PR DESCRIPTION
## Summary
- play phone keypad tones instantly using a new `playFreqs` helper
- add AOL-style modem noise button that inserts ~5s of random notes and bumps tempo
- provide programmatic tests for modem noise generation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c3f9244244832998b89d0a1fc9633d